### PR TITLE
Add command to format client files

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# PR 26: Add command to format client files
+62035b317dea8ed31b36fd22d577fc35d3e3e8b8

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+wsi_superpixel_guided_labeling/web_client/.eslintcache
 
 # pyenv
 .python-version

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,17 @@ commands =
     twine check {distdir}/*
     twine upload --skip-existing {distdir}/*
 
+[testenv:formatclient]
+skip_install = true
+usedevelop = false
+deps =
+changedir = {toxinidir}/wsi_superpixel_guided_labeling/web_client
+allowlist_externals =
+    npm
+commands =
+    npm install --no-package-lock
+    npm run format
+
 [flake8]
 max-line-length = 100
 show-source = True

--- a/wsi_superpixel_guided_labeling/web_client/package.json
+++ b/wsi_superpixel_guided_labeling/web_client/package.json
@@ -41,14 +41,13 @@
     "devDependencies": {
         "@girder/eslint-config": "*",
         "@girder/pug-lint-config": "*",
-        "eslint": "^5",
-        "eslint-config-semistandard": "^13",
-        "eslint-config-standard": "^12",
-        "eslint-plugin-backbone": "*",
-        "eslint-plugin-import": "*",
-        "eslint-plugin-node": "*",
-        "eslint-plugin-promise": "*",
-        "eslint-plugin-standard": "*",
+        "eslint": "^8.20.0",
+        "eslint-config-semistandard": "17.0.0",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-backbone": "^2.1.1",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-n": "^15.2.4",
+        "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-vue": "^9.10.0",
         "pug-lint": "^2",
         "stylint": "^2"
@@ -56,7 +55,7 @@
     "eslintConfig": {
         "extends": [
             "@girder",
-            "plugin:vue/recommend"
+            "plugin:vue/recommended"
         ],
         "overrides": [
             {

--- a/wsi_superpixel_guided_labeling/web_client/package.json
+++ b/wsi_superpixel_guided_labeling/web_client/package.json
@@ -21,7 +21,8 @@
         "webpack": "webpack.helper"
     },
     "scripts": {
-        "lint": "eslint . && pug-lint . && stylint"
+        "lint": "eslint . && pug-lint . && stylint",
+        "format": "eslint --cache --fix ."
     },
     "dependencies": {
         "@vue/compiler-sfc": "^3.2.33",

--- a/wsi_superpixel_guided_labeling/web_client/package.json
+++ b/wsi_superpixel_guided_labeling/web_client/package.json
@@ -48,11 +48,26 @@
         "eslint-plugin-node": "*",
         "eslint-plugin-promise": "*",
         "eslint-plugin-standard": "*",
+        "eslint-plugin-vue": "^9.10.0",
         "pug-lint": "^2",
         "stylint": "^2"
     },
     "eslintConfig": {
-        "extends": "@girder",
+        "extends": [
+            "@girder",
+            "plugin:vue/recommend"
+        ],
+        "overrides": [
+            {
+                "files": [
+                    "*.js",
+                    "*.vue"
+                ]
+            }
+        ],
+        "rules": {
+            "vue/require-prop-types": "off"
+        },
         "root": true
     },
     "pugLintConfig": {

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -21,7 +21,7 @@ const activeLearningSteps = {
     GuidedLabeling: 2
 };
 
-var ActiveLearningView = View.extend({
+const ActiveLearningView = View.extend({
     initialize(settings) {
         this.render();
         router.setQuery(); // Ensure we can get the folder from the router
@@ -104,7 +104,7 @@ var ActiveLearningView = View.extend({
                 vm = new ActiveLearningContainer({
                     el,
                     propsData: {
-                        router: router,
+                        router,
                         trainingDataFolderId: this.trainingDataFolderId,
                         annotationsByImageId: this.annotationsByImageId,
                         annotationBaseName: this.annotationBaseName,
@@ -123,7 +123,7 @@ var ActiveLearningView = View.extend({
                     el,
                     propsData: {
                         backboneParent: this,
-                        imageNamesById: imageNamesById,
+                        imageNamesById,
                         annotationsByImageId: this.annotationsByImageId,
                         activeLearningStep: this.activeLearningStep
                     }
@@ -263,18 +263,18 @@ var ActiveLearningView = View.extend({
                 const agreeChoice = (labelValues[index] === 0) ? undefined : (labelValues[index] === pixelmapValues[index]) ? 'Yes' : 'No';
                 const selectedCategory = (labelValues[index] === 0) ? undefined : labelValues[index];
                 superPixelConfidenceData.push({
-                    index: index,
+                    index,
                     confidence: score,
                     certainty: score,
-                    imageId: imageId,
-                    superpixelImageId: superpixelImageId,
-                    boundaries: boundaries,
-                    scale: scale,
-                    bbox: bbox,
+                    imageId,
+                    superpixelImageId,
+                    boundaries,
+                    scale,
+                    bbox,
                     prediction: pixelmapValues[index],
                     categories: superpixelCategories,
-                    agreeChoice: agreeChoice,
-                    selectedCategory: selectedCategory
+                    agreeChoice,
+                    selectedCategory
                 });
             });
         });
@@ -311,7 +311,7 @@ var ActiveLearningView = View.extend({
         restRequest({
             method: 'POST',
             url: `slicer_cli_web/${this.activeLearningJobUrl}/run`,
-            data: data
+            data
         }).done((response) => {
             const newJobId = response._id;
             this.waitForJobCompletion(newJobId, goToNextStep);
@@ -328,8 +328,8 @@ var ActiveLearningView = View.extend({
             images: this.trainingDataFolderId,
             annotationDir: annotationsFolderId,
             features: featuresFolderId,
-            magnification: magnification,
-            radius: radius,
+            magnification,
+            radius,
             labels: JSON.stringify([]),
             modeldir: modelsFolderId,
             girderApiUrl: '',

--- a/wsi_superpixel_guided_labeling/web_client/views/itemList.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/itemList.js
@@ -5,7 +5,7 @@ import { restRequest } from '@girder/core/rest';
 
 wrap(ItemListWidget, 'render', function (render) {
     render.call(this);
-    const activeLearningFolder = this.parentView.parentModel.get('meta')['active_learning'];
+    const activeLearningFolder = this.parentView.parentModel.get('meta').active_learning;
     if (activeLearningFolder) {
         const largeImageItems = _.filter(this.collection.models, (model) => model.attributes.largeImage);
         // don't make the request if the button already exists

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
@@ -1,5 +1,5 @@
 <script>
-/* global geo */
+/* global geo */ // eslint-disable-line no-unused-vars
 import Vue from 'vue';
 import _ from 'underscore';
 import { restRequest } from '@girder/core/rest';
@@ -13,7 +13,7 @@ import { store } from './store.js';
 export default Vue.extend({
     components: {
         ActiveLearningFilmStrip,
-        ActiveLearningKeyboardShortcuts,
+        ActiveLearningKeyboardShortcuts
     },
     props: [
         'router',
@@ -57,73 +57,6 @@ export default Vue.extend({
             return store.predictions;
         }
     },
-    methods: {
-        updateMapBoundsForSelection() {
-            if (!this.viewerWidget) {
-                return;
-            }
-            const superpixel = this.superpixelsToDisplay[this.selectedIndex];
-            const bbox = superpixel.bbox;
-            const bboxWidth = bbox[2] - bbox[0];
-            const bboxHeight = bbox[3] - bbox[1];
-            const scaleX = Math.abs((2 * bboxWidth) / this.currentImageMetadata.sizeX);
-            const scaleY = Math.abs((2 * bboxHeight) / this.currentImageMetadata.sizeY);
-            const zoom = this.initialZoom - Math.log2(Math.max(scaleX, scaleY));
-            const center = {
-                x: (bbox[0] + bbox[2]) / 2,
-                y: (bbox[1] + bbox[3]) / 2
-            };
-            this.viewerWidget.viewer.zoom(zoom - 1.5);
-            this.viewerWidget.viewer.center(center);
-            this.boundingBoxFeature.data([[
-                [bbox[0], bbox[1]], [bbox[2], bbox[1]], [bbox[2], bbox[3]], [bbox[0], bbox[3]]
-            ]]);
-            this.featureLayer.draw();
-        },
-        drawSuperpixels() {
-            const annotation = this.annotationsByImageId[this.selectedImageId].superpixels;
-            this.viewerWidget.drawAnnotation(annotation);
-        },
-        createImageViewer() {
-            if (this.viewerWidget) {
-                this.viewerWidget.destroy();
-            }
-            this.viewerWidget = new ViewerWidget.geojs({
-                parentView: this.backboneParent,
-                el: this.$refs.map,
-                itemId: this.selectedImageId,
-                hoverEvents: false,
-                highlightFeatureSizeLimit: 5000,
-                scale: { position: { bottom: 20, right: 10} }
-            });
-            this.viewerWidget.on('g:imageRendered', () => {
-                this.featureLayer = this.viewerWidget.viewer.createLayer('feature', { features: ['polygon'] });
-                this.boundingBoxFeature = this.featureLayer.createFeature('polygon');
-                this.boundingBoxFeature.style({
-                    fillOpacity: 0,
-                    stroke: true,
-                    strokeWidth: 4,
-                    strokeColor: { r: 255, g: 255, b: 0 }
-                });
-                this.initialZoom = this.viewerWidget.viewer.zoom();
-                this.viewerWidget.viewer.clampBoundsX(false);
-                this.viewerWidget.viewer.clampBoundsY(false);
-
-                // Remove keyboard actions
-                const interactor = this.viewerWidget.viewer.interactor();
-                interactor.keyboard({});
-
-                this.updateMapBoundsForSelection();
-                this.drawSuperpixels();
-            });
-        },
-        saveLabelAnnotations() {
-            _.forEach(Object.keys(this.annotationsByImageId), (imageId) => {
-                const annotation = this.annotationsByImageId[imageId].labels;
-                annotation.save();
-            });
-        },
-    },
     watch: {
         selectedIndex() {
             const newImageId = this.superpixelsToDisplay[this.selectedIndex].imageId;
@@ -159,7 +92,7 @@ export default Vue.extend({
         },
         changeLog: {
             handler() {
-                const change = this.changeLog[this.changeLog.length -1];
+                const change = this.changeLog[this.changeLog.length - 1];
                 this.backboneParent.debounceSaveLabelAnnotations(change);
             },
             deep: true
@@ -198,16 +131,86 @@ export default Vue.extend({
             this.currentImageMetadata = resp;
             this.createImageViewer();
         });
+    },
+    methods: {
+        updateMapBoundsForSelection() {
+            if (!this.viewerWidget) {
+                return;
+            }
+            const superpixel = this.superpixelsToDisplay[this.selectedIndex];
+            const bbox = superpixel.bbox;
+            const bboxWidth = bbox[2] - bbox[0];
+            const bboxHeight = bbox[3] - bbox[1];
+            const scaleX = Math.abs((2 * bboxWidth) / this.currentImageMetadata.sizeX);
+            const scaleY = Math.abs((2 * bboxHeight) / this.currentImageMetadata.sizeY);
+            const zoom = this.initialZoom - Math.log2(Math.max(scaleX, scaleY));
+            const center = {
+                x: (bbox[0] + bbox[2]) / 2,
+                y: (bbox[1] + bbox[3]) / 2
+            };
+            this.viewerWidget.viewer.zoom(zoom - 1.5);
+            this.viewerWidget.viewer.center(center);
+            this.boundingBoxFeature.data([[
+                [bbox[0], bbox[1]], [bbox[2], bbox[1]], [bbox[2], bbox[3]], [bbox[0], bbox[3]]
+            ]]);
+            this.featureLayer.draw();
+        },
+        drawSuperpixels() {
+            const annotation = this.annotationsByImageId[this.selectedImageId].superpixels;
+            this.viewerWidget.drawAnnotation(annotation);
+        },
+        createImageViewer() {
+            if (this.viewerWidget) {
+                this.viewerWidget.destroy();
+            }
+            this.viewerWidget = new ViewerWidget.geojs({ // eslint-disable-line new-cap
+                parentView: this.backboneParent,
+                el: this.$refs.map,
+                itemId: this.selectedImageId,
+                hoverEvents: false,
+                highlightFeatureSizeLimit: 5000,
+                scale: { position: { bottom: 20, right: 10 } }
+            });
+            this.viewerWidget.on('g:imageRendered', () => {
+                this.featureLayer = this.viewerWidget.viewer.createLayer('feature', { features: ['polygon'] });
+                this.boundingBoxFeature = this.featureLayer.createFeature('polygon');
+                this.boundingBoxFeature.style({
+                    fillOpacity: 0,
+                    stroke: true,
+                    strokeWidth: 4,
+                    strokeColor: { r: 255, g: 255, b: 0 }
+                });
+                this.initialZoom = this.viewerWidget.viewer.zoom();
+                this.viewerWidget.viewer.clampBoundsX(false);
+                this.viewerWidget.viewer.clampBoundsY(false);
+
+                // Remove keyboard actions
+                const interactor = this.viewerWidget.viewer.interactor();
+                interactor.keyboard({});
+
+                this.updateMapBoundsForSelection();
+                this.drawSuperpixels();
+            });
+        },
+        saveLabelAnnotations() {
+            _.forEach(Object.keys(this.annotationsByImageId), (imageId) => {
+                const annotation = this.annotationsByImageId[imageId].labels;
+                annotation.save();
+            });
+        }
     }
 });
 </script>
 
 <template>
-    <div class="h-active-learning-container">
-        <active-learning-keyboard-shortcuts />
-        <div ref="map" class="h-active-learning-map"></div>
-        <active-learning-film-strip />
-    </div>
+  <div class="h-active-learning-container">
+    <active-learning-keyboard-shortcuts />
+    <div
+      ref="map"
+      class="h-active-learning-map"
+    />
+    <active-learning-film-strip />
+  </div>
 </template>
 
 <style scoped>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -32,8 +32,6 @@ export default {
             return store.backboneParent;
         }
     },
-    mounted() {
-    },
     methods: {
         previousPage() {
             store.page = store.page - 1;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -32,6 +32,8 @@ export default {
             return store.backboneParent;
         }
     },
+    mounted() {
+    },
     methods: {
         previousPage() {
             store.page = store.page - 1;
@@ -55,63 +57,61 @@ export default {
         triggerRetrain() {
             this.backboneParent.retrain();
         }
-    },
-    mounted() {
     }
-}
+};
 </script>
 
 <template>
-    <div class="h-filmstrip">
-        <!-- previous button -->
-        <button
-            class="h-filmstrip-page-btn h-filmstrip-page-btn--prev btn"
-            @click="previousPage"
-            :disabled="page === 0"
-        >
-            <i class="icon-left-circled h-filmstrip-page-icon"></i>
-        </button>
-        <active-learning-film-strip-card
-            v-for="superpixel, index in superpixelsToDisplay"
-            :key="`${superpixel.imageId}_${superpixel.index}`"
-            :index="index"
-        />
-        <button
-            class="h-filmstrip-page-btn h-filmstrip-page-btn--next btn"
-            @click="nextPage"
-            :disabled="page === maxPage"
-        >
-            <i class="icon-right-circled h-filmstrip-page-icon"></i>
-        </button>
-        <div class="h-filmstrip-workflow-btns">
-            <active-learning-stats />
-            <button
-                class="h-filmstrip-workflow-btn btn btn-primary"
-                title="Show or hide the most recent predictions"
-                @click="togglePredictions"
-            >
-                Show/hide predictions
-            </button>
-            <button
-                class="h-filmstrip-workflow-btn btn btn-primary"
-                @click="resetAll"
-            >
-                Reset All
-            </button>
-            <button
-                class="h-filmstrip-workflow-btn btn btn-primary"
-                @click="agreeAll"
-            >
-                Agree to All
-            </button>
-            <button
-                class="h-filmstrip-workflow-btn btn btn-success"
-                @click="triggerRetrain"
-            >
-                Retrain
-            </button>
-        </div>
+  <div class="h-filmstrip">
+    <!-- previous button -->
+    <button
+      class="h-filmstrip-page-btn h-filmstrip-page-btn--prev btn"
+      :disabled="page === 0"
+      @click="previousPage"
+    >
+      <i class="icon-left-circled h-filmstrip-page-icon" />
+    </button>
+    <active-learning-film-strip-card
+      v-for="superpixel, index in superpixelsToDisplay"
+      :key="`${superpixel.imageId}_${superpixel.index}`"
+      :index="index"
+    />
+    <button
+      class="h-filmstrip-page-btn h-filmstrip-page-btn--next btn"
+      :disabled="page === maxPage"
+      @click="nextPage"
+    >
+      <i class="icon-right-circled h-filmstrip-page-icon" />
+    </button>
+    <div class="h-filmstrip-workflow-btns">
+      <active-learning-stats />
+      <button
+        class="h-filmstrip-workflow-btn btn btn-primary"
+        title="Show or hide the most recent predictions"
+        @click="togglePredictions"
+      >
+        Show/hide predictions
+      </button>
+      <button
+        class="h-filmstrip-workflow-btn btn btn-primary"
+        @click="resetAll"
+      >
+        Reset All
+      </button>
+      <button
+        class="h-filmstrip-workflow-btn btn btn-primary"
+        @click="agreeAll"
+      >
+        Agree to All
+      </button>
+      <button
+        class="h-filmstrip-workflow-btn btn btn-success"
+        @click="triggerRetrain"
+      >
+        Retrain
+      </button>
     </div>
+  </div>
 </template>
 
 <style scoped>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -8,7 +8,7 @@ export default Vue.extend({
     props: ['index'],
     computed: {
         superpixelDecision() {
-            return store.superpixelsToDisplay[this.index]
+            return store.superpixelsToDisplay[this.index];
         },
         agreeChoice() {
             return this.superpixelDecision.agreeChoice;
@@ -20,7 +20,7 @@ export default Vue.extend({
             return this.superpixelDecision.selectedCategory;
         },
         labelAnnotation() {
-            return store.annotationsByImageId[this.superpixelDecision.imageId]['labels'];
+            return store.annotationsByImageId[this.superpixelDecision.imageId].labels;
         },
         apiRoot() {
             return store.apiRoot;
@@ -91,22 +91,6 @@ export default Vue.extend({
             return `${this.apiRoot}/item/${imageId}/tiles/region${params}${functionParam}`;
         }
     },
-
-    methods: {
-        selectSuperpixelCard() {
-            store.selectedIndex = this.index;
-        },
-        onCategorySelectChange() {
-            store.changeLog.push(this.superpixelDecision);
-        },
-        /**
-         * Have a way to map between different lists of categories so that when we set the category for
-         * the current superpixel, we use the right index.
-         */
-        categoryIndex(label) {
-            return _.map(this.superpixelDecision.categories, (category) => category.label).indexOf(label);
-        }
-    },
     watch: {
         agreeChoice() {
             if (this.agreeChoice === 'Yes') {
@@ -152,73 +136,89 @@ export default Vue.extend({
         }
     },
     mounted() {
-        if(!this.superpixelDecision.selectedCategory) {
-           this.superpixelDecision.selectedCategory = 0;
+        if (!this.superpixelDecision.selectedCategory) {
+            this.superpixelDecision.selectedCategory = 0;
+        }
+    },
+
+    methods: {
+        selectSuperpixelCard() {
+            store.selectedIndex = this.index;
+        },
+        onCategorySelectChange() {
+            store.changeLog.push(this.superpixelDecision);
+        },
+        /**
+         * Have a way to map between different lists of categories so that when we set the category for
+         * the current superpixel, we use the right index.
+         */
+        categoryIndex(label) {
+            return _.map(this.superpixelDecision.categories, (category) => category.label).indexOf(label);
         }
     }
 });
 </script>
 
 <template>
-    <div :class="{'h-superpixel-card': true, 'h-superpixel-card--selected': isSelected }">
-        <div
-            class="h-superpixel-card-header"
-            :style="headerStyle"
-            :title="headerConfidence"
+  <div :class="{'h-superpixel-card': true, 'h-superpixel-card--selected': isSelected }">
+    <div
+      class="h-superpixel-card-header"
+      :style="headerStyle"
+      :title="headerConfidence"
+    >
+      {{ headerTitle }}
+    </div>
+    <div class="h-superpixel-body">
+      <div
+        class="h-superpixel-container"
+        @click="selectSuperpixelCard"
+      >
+        <img
+          class="h-superpixel-img h-wsi-region"
+          :src="wsiRegionUrl"
         >
-            {{ headerTitle }}
-        </div>
-        <div class="h-superpixel-body">
-            <div
-                class="h-superpixel-container"
-                @click="selectSuperpixelCard"
-            >
-                <img
-                    class="h-superpixel-img h-wsi-region"
-                    :src="wsiRegionUrl"
-                />
-                <img
-                    class="h-superpixel-img h-superpixel-region"
-                    :src="superpixelRegionUrl"
-                />
-            </div>
-        </div>
-        <div class="h-superpixel-card-footer">
-            <div class="h-superpixel-card-agree h-superpixel-card-footer-content">
-                <label>Agree? </label>
-                <label for="radio-yes">Yes</label>
-                <input
-                    id="radio-yes"
-                    type="radio"
-                    value="Yes"
-                    v-model="superpixelDecision.agreeChoice"
-                />
-                <label for="radio-no">No</label>
-                <input
-                    id="radio-no"
-                    type="radio"
-                    value="No"
-                    v-model="superpixelDecision.agreeChoice"
-                />
-            </div>
-            <div
-                v-if="superpixelDecision.agreeChoice === 'No'"
-                class="h-superpixel-card-footer-content"
-            >
-                <select
-                    v-model="superpixelDecision.selectedCategory"
-                    class="h-superpixel-card-select"
-                >
-                    <option
-                        v-for="category in validNewCategories"
-                        :key="category.label"
-                        :value="categoryIndex(category.label)"
-                    >
-                        Class: {{ category.label }}
-                    </option>
-                </select>
-            </div>
-            <!-- <div
+        <img
+          class="h-superpixel-img h-superpixel-region"
+          :src="superpixelRegionUrl"
+        >
+      </div>
+    </div>
+    <div class="h-superpixel-card-footer">
+      <div class="h-superpixel-card-agree h-superpixel-card-footer-content">
+        <label>Agree? </label>
+        <label for="radio-yes">Yes</label>
+        <input
+          id="radio-yes"
+          v-model="superpixelDecision.agreeChoice"
+          type="radio"
+          value="Yes"
+        >
+        <label for="radio-no">No</label>
+        <input
+          id="radio-no"
+          v-model="superpixelDecision.agreeChoice"
+          type="radio"
+          value="No"
+        >
+      </div>
+      <div
+        v-if="superpixelDecision.agreeChoice === 'No'"
+        class="h-superpixel-card-footer-content"
+      >
+        <select
+          v-model="superpixelDecision.selectedCategory"
+          class="h-superpixel-card-select"
+        >
+          <option
+            v-for="category in validNewCategories"
+            :key="category.label"
+            :value="categoryIndex(category.label)"
+          >
+            Class: {{ category.label }}
+          </option>
+        </select>
+      </div>
+      <!-- <div
                 v-else
                 class="h-superpixel-card-footer-content"
             >
@@ -231,8 +231,8 @@ export default Vue.extend({
                     </option>
                 </select>
             </div> -->
-        </div>
     </div>
+  </div>
 </template>
 
 <style scoped>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -218,19 +218,6 @@ export default Vue.extend({
           </option>
         </select>
       </div>
-      <!-- <div
-                v-else
-                class="h-superpixel-card-footer-content"
-            >
-                <select
-                    disabled="true"
-                    class="h-superpixel-card-select"
-                >
-                    <option :value="predictedCategory">
-                        Class: {{ predictedCategory.label }}
-                    </option>
-                </select>
-            </div> -->
     </div>
   </div>
 </template>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -1,7 +1,9 @@
 <script>
 import Vue from 'vue';
-import { store, previousCard, nextCard } from './store.js';
+
 import _ from 'underscore';
+
+import { store, previousCard, nextCard } from './store.js';
 
 export default Vue.extend({
     data() {
@@ -20,6 +22,9 @@ export default Vue.extend({
             });
         }
     },
+    mounted() {
+        window.addEventListener('keydown', this.keydownListener);
+    },
     methods: {
         keydownListener(event) {
             // If support for > 9 categories is necessary, this will
@@ -29,7 +34,7 @@ export default Vue.extend({
                 store.lastCategorySelected = parseInt(event.key);
                 return;
             }
-            switch(event.key) {
+            switch (event.key) {
                 case 'ArrowRight':
                     nextCard();
                     break;
@@ -38,50 +43,47 @@ export default Vue.extend({
                     break;
             }
         }
-    },
-    mounted() {
-        window.addEventListener('keydown', this.keydownListener);
     }
 });
 </script>
 
 <template>
-    <div class="h-hotkeys-container">
-        <div class="h-hotkeys-header">
-        <h5>Hotkeys</h5>
-        <button
-            class="h-hotkeys-toggle"
-            @click="showShortcuts = !showShortcuts"
-        >
-            <i
-                v-if="showShortcuts"
-                class="icon-up-open"
-            />
-            <i
-                v-else
-                class="icon-down-open"
-            />
-        </button>
-        </div>
-        <div v-if="showShortcuts">
-            <h6>Navigation</h6>
-            <span class="h-hotkey">
-                Right Arrow - Next Superpixel
-            </span>
-            <span class="h-hotkey">
-                Left Arrow - Previous Superpixel
-            </span>
-            <h6>Labeling</h6>
-            <span class="h-hotkey">0 - Reset selection</span>
-            <span
-                class="h-hotkey"
-                v-for="(category, index) in nonDefaultCategories"
-                :key="category.label"
-            >
-                {{ index + 1}} - {{ category.label }}
-            </span>
-        </div>
+  <div class="h-hotkeys-container">
+    <div class="h-hotkeys-header">
+      <h5>Hotkeys</h5>
+      <button
+        class="h-hotkeys-toggle"
+        @click="showShortcuts = !showShortcuts"
+      >
+        <i
+          v-if="showShortcuts"
+          class="icon-up-open"
+        />
+        <i
+          v-else
+          class="icon-down-open"
+        />
+      </button>
     </div>
+    <div v-if="showShortcuts">
+      <h6>Navigation</h6>
+      <span class="h-hotkey">
+        Right Arrow - Next Superpixel
+      </span>
+      <span class="h-hotkey">
+        Left Arrow - Previous Superpixel
+      </span>
+      <h6>Labeling</h6>
+      <span class="h-hotkey">0 - Reset selection</span>
+      <span
+        v-for="(category, index) in nonDefaultCategories"
+        :key="category.label"
+        class="h-hotkey"
+      >
+        {{ index + 1 }} - {{ category.label }}
+      </span>
+    </div>
+  </div>
 </template>
 
 <style scoped>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningStats.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningStats.vue
@@ -16,24 +16,21 @@ export default {
         iconClicked() {
             this.showStatsCard = !this.showStatsCard;
         }
-    },
-}
+    }
+};
 </script>
 
 <template>
-    <div>
-        <div :class="{ 'h-al-stats-card': true, 'h-al-no-display': !showStatsCard }">
-            Avg. Confidence this epoch: {{ averageConfidence }}
-        </div>
-        <span
-            class="icon-help-circled h-al-stats-anchor"
-            title="Click to show epoch statistics"
-            @click="iconClicked"
-        >
-
-        </span>
+  <div>
+    <div :class="{ 'h-al-stats-card': true, 'h-al-no-display': !showStatsCard }">
+      Avg. Confidence this epoch: {{ averageConfidence }}
     </div>
-
+    <span
+      class="icon-help-circled h-al-stats-anchor"
+      title="Click to show epoch statistics"
+      @click="iconClicked"
+    />
+  </div>
 </template>
 
 <style scoped>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
@@ -1,6 +1,5 @@
 <script>
 import Vue from 'vue';
-import _ from 'underscore';
 
 export default Vue.extend({
     props: ['backboneParent'],
@@ -8,7 +7,7 @@ export default Vue.extend({
         return {
             radius: 100,
             magnification: 5
-        }
+        };
     },
     computed: {
         validForm() {
@@ -24,35 +23,39 @@ export default Vue.extend({
 </script>
 
 <template>
-    <div class="h-al-setup-superpixels">
-        <div class = "form-group">
-            <label for="radius">Superpixel Radius</label>
-            <div class="form-group-description">Approximate superpixel radius</div>
-            <input
-                id="radius"
-                class="form-control input-sm h-active-learning-input"
-                v-model.number="radius"
-                type="number"
-            >
-        </div>
-        <div class="form-group">
-            <label for="magnification">Magnification</label>
-            <div class="form-group-description">Image magnification for superpixel generation</div>
-            <input
-                id="magnification"
-                class="form-control input-sm h-active-learning-input"
-                v-model.number="magnification"
-                type="number"
-            >
-        </div>
-        <button
-            class="btn btn-primary h-generate-superpixel-btn"
-            :disabled="!validForm"
-            @click="generateInitialSuperpixels"
-        >
-            Generate Superpixels
-        </button>
+  <div class="h-al-setup-superpixels">
+    <div class="form-group">
+      <label for="radius">Superpixel Radius</label>
+      <div class="form-group-description">
+        Approximate superpixel radius
+      </div>
+      <input
+        id="radius"
+        v-model.number="radius"
+        class="form-control input-sm h-active-learning-input"
+        type="number"
+      >
     </div>
+    <div class="form-group">
+      <label for="magnification">Magnification</label>
+      <div class="form-group-description">
+        Image magnification for superpixel generation
+      </div>
+      <input
+        id="magnification"
+        v-model.number="magnification"
+        class="form-control input-sm h-active-learning-input"
+        type="number"
+      >
+    </div>
+    <button
+      class="btn btn-primary h-generate-superpixel-btn"
+      :disabled="!validForm"
+      @click="generateInitialSuperpixels"
+    >
+      Generate Superpixels
+    </button>
+  </div>
 </template>
 
 <style scoped>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningSetupContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningSetupContainer.vue
@@ -1,32 +1,31 @@
 <script>
 import Vue from 'vue';
-import _ from 'underscore';
+
 import ActiveLearningInitialSuperpixels from './ActiveLearningInitialSuperpixels.vue';
-import ActiveLearningInitialLabels from './ActiveLearningInitialLabels.vue'
+import ActiveLearningInitialLabels from './ActiveLearningInitialLabels.vue';
 
 export default Vue.extend({
-    props: ['backboneParent', 'imageNamesById', 'annotationsByImageId', 'activeLearningStep'],
     components: {
         ActiveLearningInitialSuperpixels,
         ActiveLearningInitialLabels
-    }
+    },
+    props: ['backboneParent', 'imageNamesById', 'annotationsByImageId', 'activeLearningStep']
 });
 </script>
 
 <template>
-    <div class="h-active-learning-container">
-        <active-learning-initial-superpixels
-            v-if="activeLearningStep === 0"
-            :backboneParent="backboneParent"
-        />
-        <active-learning-initial-labels
-            v-else
-            :backboneParent="backboneParent"
-            :imageNamesById="imageNamesById"
-            :annotationsByImageId="annotationsByImageId"
-        />
-
-    </div>
+  <div class="h-active-learning-container">
+    <active-learning-initial-superpixels
+      v-if="activeLearningStep === 0"
+      :backbone-parent="backboneParent"
+    />
+    <active-learning-initial-labels
+      v-else
+      :backbone-parent="backboneParent"
+      :image-names-by-id="imageNamesById"
+      :annotations-by-image-id="annotationsByImageId"
+    />
+  </div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
This PR adds a new command to format client JS and Vue files (`tox -e formatclient`). Some of the dev dependencies were updated to make this work as expected.

Additionally, the existing client files have been formatted, including some manual changes like removing non-functional or superfluous code.