### PR TITLE
Improve usability of the initial label viewer

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -128,6 +128,7 @@ export default Vue.extend({
                 el: this.$refs.map,
                 itemId: this.currentImageId
             });
+            this.viewerWidget.setUnclampBoundsForOverlay(false);
             this.viewerWidget.on('g:imageRendered', this.drawPixelmapAnnotation);
             this.viewerWidget.on('g:drawOverlayAnnotation', (element, layer) => {
                 if (element.type === 'pixelmap') {
@@ -390,7 +391,8 @@ export default Vue.extend({
 }
 .h-setup-categories-map {
     width: 67%;
-    height: 100%;
+    height: 600px;
+    border: 1px solid #f0f0f0;
 }
 .h-al-image-selector {
     display: block;


### PR DESCRIPTION
Fixes #35 

For the image viewer in the initial labels view, the following changes were made to increase usability of the activity.

1. Bounds are clamped: Now you can't push the image way out of bounds
2. The viewer has a border: Now it is easier to see the edge of the image viewer window
3. The viewer has a fixed height: This prevents the viewer from running right up against the bottom of the window.

![image](https://user-images.githubusercontent.com/7085625/236928431-217dd787-b914-4828-987e-ee473d5b1353.png)