### PR TITLE
Fix running counts of labeled superpixels

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -49,13 +49,17 @@ export default Vue.extend({
         },
         labeledSuperpixelCounts() {
             const counts = {};
-            _.forEach(this.categories, (categoryAndIndices) => {
+            _.forEach(this.categories, (categoryAndIndices, index) => {
                 const label = categoryAndIndices.category.label;
-                counts[label] = 0;
+                const key = `${index}_${label}`;
+                counts[key] = {
+                    count: 0,
+                    label
+                };
                 if (label !== 'default') {
                     const indicesByImage = categoryAndIndices.indices;
-                    _.forEach(Object.values(indicesByImage), (indicesArray) => {
-                        counts[label] += indicesArray.length;
+                    _.forEach(Object.values(indicesByImage), (indicesSet) => {
+                        counts[key].count += indicesSet.size;
                     });
                 }
             });
@@ -174,10 +178,10 @@ export default Vue.extend({
                 if (categoryIndex !== 0) {
                     // For each non-default category, get all the labeled indices
                     // for this superpixel element.
-                    const labeledSuperpixels = [];
+                    const labeledSuperpixels = new Set();
                     _.forEach(pixelmapElement.values, (value, index) => {
                         if (value === categoryIndex) {
-                            labeledSuperpixels.push(index);
+                            labeledSuperpixels.add(index);
                         }
                     });
                     // Either add the category to the initial label UI,
@@ -229,13 +233,14 @@ export default Vue.extend({
             const index = boundaries ? (event.index - event.index % 2) : event.index;
             const offset = boundaries ? 1 : 0;
             const data = this.overlayLayer.data();
-            // the +1 accounts for the default, reset to default if already labeled
-            const categoryIndex = data[index] === 0 ? this.categoryIndex + 1 : 0;
-            data[index] = data[index + offset] = categoryIndex;
+            const previousLabel = data[index];
+            // the +1 accounts for the default, reset to default if already labeled with the selected category
+            const newLabel = previousLabel !== this.categoryIndex + 1 ? this.categoryIndex + 1 : 0;
+            data[index] = data[index + offset] = newLabel;
             this.overlayLayer.indexModified(index, index + offset).draw();
 
             this.saveNewPixelmapData(boundaries, _.clone(data));
-            this.updateRunningLabelCounts(boundaries, index, categoryIndex);
+            this.updateRunningLabelCounts(boundaries, index, newLabel, previousLabel);
         },
         saveNewPixelmapData(boundaries, data) {
             const annotation = this.superpixelAnnotation.get('annotation');
@@ -246,18 +251,23 @@ export default Vue.extend({
             superpixelElement.values = data;
             this.debounceSaveAnnotations();
         },
-        updateRunningLabelCounts(boundaries, index, categoryIndex) {
+        updateRunningLabelCounts(boundaries, index, newLabel, oldLabel) {
             const elementValueIndex = boundaries ? index / 2 : index;
-            const currentCategoryIndices = this.categories[this.categoryIndex].indices[this.currentImageId] || [];
-            if (categoryIndex === 0) {
-                this.categories[this.categoryIndex].indices[this.currentImageId] = _.filter(currentCategoryIndices, (i) => i !== elementValueIndex);
-            } else {
-                currentCategoryIndices.push(elementValueIndex);
+            const currentCategoryIndices = this.categories[this.categoryIndex].indices[this.currentImageId] || new Set();
+            if (!currentCategoryIndices.size) {
                 this.categories[this.categoryIndex].indices[this.currentImageId] = currentCategoryIndices;
-                // Force computed properties to update
-                const newCategoryData = Object.assign({}, this.categories[this.categoryIndex]);
-                this.categories.splice(this.categoryIndex, 1, newCategoryData);
             }
+            if (newLabel === 0) {
+                currentCategoryIndices.delete(elementValueIndex);
+            } else if (oldLabel === 0) {
+                currentCategoryIndices.add(elementValueIndex);
+            } else {
+                this.categories[oldLabel - 1].indices[this.currentImageId].delete(elementValueIndex);
+                currentCategoryIndices.add(elementValueIndex);
+            }
+            // Force computed properties to update
+            const newCategoryData = Object.assign({}, this.categories[this.categoryIndex]);
+            this.categories.splice(this.categoryIndex, 1, newCategoryData);
         },
         /*************************
          * RESPOND TO USER INPUT *
@@ -364,10 +374,10 @@ export default Vue.extend({
       />
       <div class="h-category-setup-progress">
         <div
-          v-for="(label, index) in Object.keys(labeledSuperpixelCounts)"
+          v-for="(key, index) in Object.keys(labeledSuperpixelCounts)"
           :key="index"
         >
-          {{ label }}: {{ labeledSuperpixelCounts[label] }} superpixels labeled
+          {{ labeledSuperpixelCounts[key].label }}: {{ labeledSuperpixelCounts[key].count }} superpixels labeled
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #32 

Now, superpixel counts will change when re-labelling a superpixel. Additionally, Sets are used instead of arrays, and if two categories have the same name, they will both display in the running counts.

To reproduce the bug described in #32:
1. Open the initial labels view and label some superpixels with the initial category.
2. Create a new category
3. Label some of the previously labeled superpixels with the new category
4. Running count of the old category stays the same

To verify the fix in this PR, repeat the above steps, but in step 4, you should see the count update to reflect re-labeling.

While testing this PR, I discovered another issue where if two categories had the same name, they wouldn't show up separately in the running counts. Now, two categories can have the same name, and they will each have a line in the running counts section.
