### PR TITLE
Enable different metrics for certainty

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -112,7 +112,7 @@ const ActiveLearningView = View.extend({
                         sortedSuperpixelIndices: this.sortedSuperpixelIndices,
                         apiRoot: getApiRoot(),
                         backboneParent: this,
-                        currentAverageConfidence: this.currentAverageConfidence
+                        currentAverageCertainty: this.currentAverageCertainty
                     }
                 });
             } else {
@@ -243,13 +243,13 @@ const ActiveLearningView = View.extend({
     },
 
     computeAverageCertainty(annotation) {
-        const confidenceArray = annotation.get('annotation').elements[0].user.confidence;
-        const sum = _.reduce(confidenceArray, (sum, num) => sum + num, 0);
-        this.currentAverageConfidence = sum / confidenceArray.length;
+        const certaintyArray = annotation.get('annotation').elements[0].user.certainty;
+        const sum = _.reduce(certaintyArray, (sum, num) => sum + num, 0);
+        this.currentAverageCertainty = sum / certaintyArray.length;
     },
 
     getSortedSuperpixelIndices() {
-        const superPixelConfidenceData = [];
+        const superpixelPredictionsData = [];
         _.forEach(Object.keys(this.annotationsByImageId), (imageId) => {
             const annotation = this.annotationsByImageId[imageId].predictions.get('annotation');
             const labels = this.annotationsByImageId[imageId].labels.get('annotation');
@@ -260,13 +260,13 @@ const ActiveLearningView = View.extend({
             const superpixelCategories = annotation.elements[0].categories;
             const boundaries = annotation.elements[0].boundaries;
             const scale = annotation.elements[0].transform.matrix[0][0];
-            _.forEach(userData.confidence, (score, index) => {
+            _.forEach(userData.certainty, (score, index) => {
                 const bbox = userData.bbox.slice(index * 4, index * 4 + 4);
                 const agreeChoice = (labelValues[index] === 0) ? undefined : (labelValues[index] === pixelmapValues[index]) ? 'Yes' : 'No';
                 const selectedCategory = (labelValues[index] === 0) ? undefined : labelValues[index];
-                superPixelConfidenceData.push({
+                superpixelPredictionsData.push({
                     index,
-                    confidence: score,
+                    confidence: userData.confidence[index],
                     certainty: score,
                     imageId,
                     superpixelImageId,
@@ -280,7 +280,7 @@ const ActiveLearningView = View.extend({
                 });
             });
         });
-        this.sortedSuperpixelIndices = _.sortBy(superPixelConfidenceData, 'certainty');
+        this.sortedSuperpixelIndices = _.sortBy(superpixelPredictionsData, 'certainty');
     },
 
     getJobXmlUrl() {

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -126,7 +126,8 @@ const ActiveLearningView = View.extend({
                         backboneParent: this,
                         imageNamesById,
                         annotationsByImageId: this.annotationsByImageId,
-                        activeLearningStep: this.activeLearningStep
+                        activeLearningStep: this.activeLearningStep,
+                        certaintyMetrics: this.certaintyMetrics
                     }
                 });
             }
@@ -336,12 +337,12 @@ const ActiveLearningView = View.extend({
         }).then((xmlSpec) => {
             const gui = parse(xmlSpec);
             const flattenedSpec = this.flattenParse(gui);
-            const hasCertaintyOptions = (
+            const hasCertaintyMetrics = (
                 flattenedSpec.parameters.certainty &&
                 flattenedSpec.parameters.certainty.values &&
                 flattenedSpec.parameters.certainty.values.length
             );
-            this.certaintyOptions = hasCertaintyOptions ? flattenedSpec.parameters.certainty.values : null;
+            this.certaintyMetrics = hasCertaintyMetrics ? flattenedSpec.parameters.certainty.values : null;
             return this.mountVueComponent();
         });
     },
@@ -383,7 +384,7 @@ const ActiveLearningView = View.extend({
         });
     },
 
-    generateInitialSuperpixels(radius, magnification) {
+    generateInitialSuperpixels(radius, magnification, certaintyMetric) {
         // get the folders to store annotations, models, features
         const folders = this.childFolders.models;
         const annotationsFolderId = _.filter(folders, (folder) => folder.get('name') === 'Annotations')[0].get('_id');
@@ -398,7 +399,8 @@ const ActiveLearningView = View.extend({
             labels: JSON.stringify([]),
             modeldir: modelsFolderId,
             girderApiUrl: '',
-            girderToken: ''
+            girderToken: '',
+            certainty: certaintyMetric
         };
         this.triggerJob(data, true);
     },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
@@ -23,7 +23,7 @@ export default Vue.extend({
         'sortedSuperpixelIndices',
         'apiRoot',
         'backboneParent',
-        'currentAverageConfidence'
+        'currentAverageCertainty'
     ],
     data() {
         return {
@@ -108,7 +108,7 @@ export default Vue.extend({
         store.pageSize = this.pageSize;
         store.selectedIndex = 0;
         store.predictions = false;
-        store.currentAverageConfidence = this.currentAverageConfidence;
+        store.currentAverageCertainty = this.currentAverageCertainty;
 
         const predictionAnnotation = this.annotationsByImageId[this.selectedImageId].predictions;
         const predictionCategories = predictionAnnotation.get('annotation').elements[0].categories;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -43,8 +43,8 @@ export default Vue.extend({
         headerTitle() {
             return `Prediction: ${this.predictedCategory.label}`;
         },
-        headerConfidence() {
-            return `Confidence ${this.superpixelDecision.confidence.toFixed(5)}`;
+        headerCertainty() {
+            return `Certainty ${this.superpixelDecision.certainty.toFixed(5)}`;
         },
         validNewCategories() {
             const categories = this.superpixelDecision.categories;
@@ -164,7 +164,7 @@ export default Vue.extend({
     <div
       class="h-superpixel-card-header"
       :style="headerStyle"
-      :title="headerConfidence"
+      :title="headerCertainty"
     >
       {{ headerTitle }}
     </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningStats.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningStats.vue
@@ -8,8 +8,8 @@ export default {
         };
     },
     computed: {
-        averageConfidence() {
-            return store.currentAverageConfidence;
+        averageCertainty() {
+            return store.currentAverageCertainty;
         }
     },
     methods: {
@@ -23,7 +23,7 @@ export default {
 <template>
   <div>
     <div :class="{ 'h-al-stats-card': true, 'h-al-no-display': !showStatsCard }">
-      Avg. Confidence this epoch: {{ averageConfidence }}
+      Avg. Certainty this epoch: {{ averageCertainty }}
     </div>
     <span
       class="icon-help-circled h-al-stats-anchor"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/store.js
@@ -12,7 +12,7 @@ const store = Vue.observable({
     annotationsByImageId: {},
     backboneParent: null,
     predictions: false,
-    currentAverageConfidence: 0,
+    currentAverageCertainty: 0,
     categories: [],
     lastCategorySelected: null
 });

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
@@ -2,11 +2,12 @@
 import Vue from 'vue';
 
 export default Vue.extend({
-    props: ['backboneParent'],
+    props: ['backboneParent', 'certaintyMetrics'],
     data() {
         return {
             radius: 100,
-            magnification: 5
+            magnification: 5,
+            certaintyChoice: ''
         };
     },
     computed: {
@@ -14,9 +15,16 @@ export default Vue.extend({
             return this.radius > 0 && this.magnification > 0;
         }
     },
+    mounted() {
+        this.certaintyChoice = this.certaintyMetrics[0];
+    },
     methods: {
         generateInitialSuperpixels() {
-            this.backboneParent.generateInitialSuperpixels(this.radius, this.magnification);
+            this.backboneParent.generateInitialSuperpixels(
+                this.radius,
+                this.magnification,
+                this.certaintyChoice
+            );
         }
     }
 });
@@ -47,6 +55,24 @@ export default Vue.extend({
         class="form-control input-sm h-active-learning-input"
         type="number"
       >
+    </div>
+    <div class="form-group">
+      <label for="certainty-metric">Certainty Metric</label>
+      <div class="form-group-description">
+        Metric to determine the order that predictions are presented to the user
+      </div>
+      <select
+        id="certainty-metric"
+        v-model="certaintyChoice"
+      >
+        <option
+          v-for="option in certaintyMetrics"
+          :key="option"
+          :value="option"
+        >
+          {{ option }}
+        </option>
+      </select>
     </div>
     <button
       class="btn btn-primary h-generate-superpixel-btn"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningSetupContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningSetupContainer.vue
@@ -9,7 +9,13 @@ export default Vue.extend({
         ActiveLearningInitialSuperpixels,
         ActiveLearningInitialLabels
     },
-    props: ['backboneParent', 'imageNamesById', 'annotationsByImageId', 'activeLearningStep']
+    props: [
+        'backboneParent',
+        'imageNamesById',
+        'annotationsByImageId',
+        'activeLearningStep',
+        'certaintyMetrics'
+    ]
 });
 </script>
 
@@ -18,6 +24,7 @@ export default Vue.extend({
     <active-learning-initial-superpixels
       v-if="activeLearningStep === 0"
       :backbone-parent="backboneParent"
+      :certainty-metrics="certaintyMetrics"
     />
     <active-learning-initial-labels
       v-else


### PR DESCRIPTION
Previously, the SuperpixelClassification job provided the certainty per prediction as a straightforward confidence measurement.

Now, thanks to https://github.com/DigitalSlideArchive/ALBench/pull/48 and https://github.com/DigitalSlideArchive/superpixel-classification/pull/4, we can pick one of three certainty metrics at the start of training (confidence, margin, and negative entropy).

In order to get available metrics, we get the XML definition for the SuperpixelClassification there, and parse the document to find them. The choice is made by the user during step one of active learning. A dropdown menu has been added as part of that form.