### PR TITLE
Remove hotkey listener on destroy

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -25,6 +25,9 @@ export default Vue.extend({
     mounted() {
         window.addEventListener('keydown', this.keydownListener);
     },
+    destroyed() {
+        window.removeEventListener('keydown', this.keydownListener);
+    },
     methods: {
         keydownListener(event) {
             // If support for > 9 categories is necessary, this will


### PR DESCRIPTION
### Bug Description
On the main guided labeling UI, the component that registers the hotkeys for labeling superpixels never un-registers the event listener. Since the listener is bound to the window, clicking `Retrain` and waiting until retrain was finished would double-bind the keyboard shortcuts. For example, trying to move to the next chip using the right arrow key would move two chips instead.

### Fix 
Now, when the component is destroyed (such as when the backbone view reloads after the retrain job is finished), the events are unregistered, and re-registered when the component is mounted again.

### Testing
1. Open the active learning UI to the main guided labeling activity. Do some labeling using the keyboard shortcuts to verify that they work properly. 
2. Retrain. Keep the window open and wait for retrain to complete
3. Once you have control over the activity again, use the hotkeys to do more labeling/navigating. Each key press should correspond to only one action