### PR TITLE
Better bookkeeping in chip label view

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -275,7 +275,6 @@ const ActiveLearningView = View.extend({
             _.forEach(userData.certainty, (score, index) => {
                 const bbox = userData.bbox.slice(index * 4, index * 4 + 4);
                 const agreeChoice = this.getAgreeChoice(index, annotation.elements[0], labels.elements[0]);
-                const selectedCategory = (labelValues[index] === 0) ? undefined : labelValues[index];
                 const prediction = {
                     index,
                     confidence: userData.confidence[index],
@@ -286,11 +285,10 @@ const ActiveLearningView = View.extend({
                     scale,
                     bbox,
                     prediction: pixelmapValues[index],
-                    label: labelValues[index],
                     predictionCategories: superpixelCategories,
                     labelCategories: labels.elements[0].categories,
                     agreeChoice,
-                    selectedCategory
+                    selectedCategory: labelValues[index]
                 };
                 superpixelPredictionsData.push(prediction);
             });

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -249,14 +249,16 @@ const ActiveLearningView = View.extend({
     },
 
     getAgreeChoice(index, predictionPixelmapElement, labelPixelmapElement) {
-        if (labelPixelmapElement.values[index] === 0) {
+        const label = labelPixelmapElement.values[index];
+        const labelCategories = labelPixelmapElement.categories;
+        if (labelCategories[label].label === 'default') {
             // Label is default, so no choice has been made
+            // Once we use the config file, we can use the default
+            // category specified there insted of the raw string
             return undefined;
         }
         const predictionCategories = predictionPixelmapElement.categories;
-        const labelCategories = labelPixelmapElement.categories;
         const prediction = predictionPixelmapElement.values[index];
-        const label = labelPixelmapElement.values[index];
         return predictionCategories[prediction].label === labelCategories[label].label ? 'Yes' : 'No';
     },
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -101,7 +101,7 @@ export default Vue.extend({
                 const currentPredictionLabel = this.superpixelDecision.predictionCategories[this.superpixelDecision.prediction].label;
                 this.superpixelDecision.selectedCategory = this.categoryIndex(currentPredictionLabel);
             } else if (this.agreeChoice === undefined || this.agreeChoice === null) {
-                this.superpixelDecision.selectedCategory = undefined;
+                this.superpixelDecision.selectedCategory = 0;
             } else {
                 // agreeChoice === 'No'
                 if (!this.superpixelDecision.selectedCategory) {
@@ -112,13 +112,6 @@ export default Vue.extend({
         selectedCategory() {
             const element = this.labelAnnotation.get('annotation').elements[0];
             const values = JSON.parse(JSON.stringify(element.values));
-            const setDefault = this.superpixelDecision.selectedCategory === null || this.superpixelDecision.selectedCategory === undefined;
-            if (setDefault) {
-                values[this.superpixelDecision.index] = 0;
-                element.values = values;
-                store.changeLog.push(this.superpixelDecision);
-                return;
-            }
             values[this.superpixelDecision.index] = this.superpixelDecision.selectedCategory;
             element.values = values;
             store.changeLog.push(this.superpixelDecision);
@@ -133,7 +126,7 @@ export default Vue.extend({
                 // Be extra careful to select the correct category
                 const newCategory = store.categories[categoryNumber];
                 const newCategoryIndex = this.categoryIndex(newCategory.label);
-                if (newCategory.label === this.predictionCategory[this.superpixelDecision.prediction].label) {
+                if (newCategory.label === this.predictedCategory.label) {
                     this.superpixelDecision.agreeChoice = 'Yes';
                 } else {
                     this.superpixelDecision.selectedCategory = newCategoryIndex;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -14,13 +14,16 @@ export default Vue.extend({
             return this.superpixelDecision.agreeChoice;
         },
         predictedCategory() {
-            return this.superpixelDecision.categories[this.superpixelDecision.prediction];
+            return this.superpixelDecision.predictionCategories[this.superpixelDecision.prediction];
         },
         selectedCategory() {
             return this.superpixelDecision.selectedCategory;
         },
         labelAnnotation() {
             return store.annotationsByImageId[this.superpixelDecision.imageId].labels;
+        },
+        predictionAnnotation() {
+            return store.annotationsByImageId[this.superpixelDecision.imageId].predictions;
         },
         apiRoot() {
             return store.apiRoot;
@@ -37,7 +40,7 @@ export default Vue.extend({
         headerStyle() {
             return {
                 'font-size': '80%',
-                'background-color': this.superpixelDecision.categories[this.superpixelDecision.prediction].fillColor
+                'background-color': this.superpixelDecision.predictionCategories[this.superpixelDecision.prediction].fillColor
             };
         },
         headerTitle() {
@@ -47,9 +50,10 @@ export default Vue.extend({
             return `Certainty ${this.superpixelDecision.certainty.toFixed(5)}`;
         },
         validNewCategories() {
-            const categories = this.superpixelDecision.categories;
-            return _.filter(categories, (c, index) => {
-                return index !== this.superpixelDecision.prediction && c.label !== 'default';
+            const categories = this.superpixelDecision.labelCategories;
+            const predictedLabel = this.superpixelDecision.predictionCategories[this.superpixelDecision.prediction].label;
+            return _.filter(categories, (c) => {
+                return !['default', predictedLabel].includes(c.label);
             });
         },
         wsiRegionUrl() {
@@ -94,22 +98,27 @@ export default Vue.extend({
     watch: {
         agreeChoice() {
             if (this.agreeChoice === 'Yes') {
-                this.superpixelDecision.selectedCategory = this.superpixelDecision.prediction;
-            } else if (this.agreeChoice === undefined) {
-                this.superpixelDecision.selectedCategory = 0;
+                const currentPredictionLabel = this.superpixelDecision.predictionCategories[this.superpixelDecision.prediction].label;
+                this.superpixelDecision.selectedCategory = this.categoryIndex(currentPredictionLabel);
+            } else if (this.agreeChoice === undefined || this.agreeChoice === null) {
+                this.superpixelDecision.selectedCategory = undefined;
             } else {
                 // agreeChoice === 'No'
-                if (!this.selectedCategory) {
+                if (!this.superpixelDecision.selectedCategory) {
                     this.superpixelDecision.selectedCategory = this.categoryIndex(this.validNewCategories[0].label);
                 }
             }
         },
-        selectedCategory(newCat, oldCat) {
-            if (oldCat === undefined) {
-                return;
-            }
+        selectedCategory() {
             const element = this.labelAnnotation.get('annotation').elements[0];
             const values = JSON.parse(JSON.stringify(element.values));
+            const setDefault = this.superpixelDecision.selectedCategory === null || this.superpixelDecision.selectedCategory === undefined;
+            if (setDefault) {
+                values[this.superpixelDecision.index] = 0;
+                element.values = values;
+                store.changeLog.push(this.superpixelDecision);
+                return;
+            }
             values[this.superpixelDecision.index] = this.superpixelDecision.selectedCategory;
             element.values = values;
             store.changeLog.push(this.superpixelDecision);
@@ -120,27 +129,24 @@ export default Vue.extend({
             }
             if (categoryNumber === 0) {
                 this.superpixelDecision.agreeChoice = undefined;
-            } else if (categoryNumber <= this.superpixelDecision.categories.length) {
+            } else if (categoryNumber <= this.superpixelDecision.predictionCategories.length) {
                 // Be extra careful to select the correct category
                 const newCategory = store.categories[categoryNumber];
                 const newCategoryIndex = this.categoryIndex(newCategory.label);
-                this.superpixelDecision.selectedCategory = newCategoryIndex;
-                if (newCategoryIndex === this.superpixelDecision.prediction) {
+                if (newCategory.label === this.predictionCategory[this.superpixelDecision.prediction].label) {
                     this.superpixelDecision.agreeChoice = 'Yes';
                 } else {
+                    this.superpixelDecision.selectedCategory = newCategoryIndex;
                     this.superpixelDecision.agreeChoice = 'No';
                 }
-                this.$nextTick(() => nextCard());
+                this.$nextTick(() => {
+                    store.lastCategorySelected = null;
+                    nextCard();
+                });
             }
             store.lastCategorySelected = null; // reset state
         }
     },
-    mounted() {
-        if (!this.superpixelDecision.selectedCategory) {
-            this.superpixelDecision.selectedCategory = 0;
-        }
-    },
-
     methods: {
         selectSuperpixelCard() {
             store.selectedIndex = this.index;
@@ -153,7 +159,7 @@ export default Vue.extend({
          * the current superpixel, we use the right index.
          */
         categoryIndex(label) {
-            return _.map(this.superpixelDecision.categories, (category) => category.label).indexOf(label);
+            return _.map(this.superpixelDecision.labelCategories, (category) => category.label).indexOf(label);
         }
     }
 });

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -23,10 +23,12 @@ export default Vue.extend({
         }
     },
     mounted() {
+        store.lastCategorySelected = null;
         window.addEventListener('keydown', this.keydownListener);
     },
     destroyed() {
         window.removeEventListener('keydown', this.keydownListener);
+        store.lastCategorySelected = null;
     },
     methods: {
         keydownListener(event) {


### PR DESCRIPTION
Fixes #51 

### Bug
Labeling chips was often incorrect, especially when the category list differed between the prediction and label annotations for the current epoch. This could be discovered in multiple ways: comparing labels in the active learning view to histomics ui, and refreshing the active learning view after making some labels.

### Fix
In order to fix this, the code no longer assumes that the label categories and prediction categories line up 1:1. Steps are taken to ensure that the agreement is properly calculated on load, and label categories are used to set new values on the label annotation.