### PR TITLE
Prevent simultaneous annotation saves

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
@@ -93,7 +93,7 @@ export default Vue.extend({
         changeLog: {
             handler() {
                 const change = this.changeLog[this.changeLog.length - 1];
-                this.backboneParent.debounceSaveLabelAnnotations(change);
+                this.backboneParent.saveLabelAnnotations([change.imageId]);
             },
             deep: true
         }
@@ -190,12 +190,6 @@ export default Vue.extend({
 
                 this.updateMapBoundsForSelection();
                 this.drawSuperpixels();
-            });
-        },
-        saveLabelAnnotations() {
-            _.forEach(Object.keys(this.annotationsByImageId), (imageId) => {
-                const annotation = this.annotationsByImageId[imageId].labels;
-                annotation.save();
             });
         }
     }


### PR DESCRIPTION
close #46 

### Previous Behavior
`_.debounce` was used to create a function that would only save annotations once every 500ms. Additionally, we always saved all current label annotations, and triggered a save incorrectly due to a vue watcher that fired more than expected.

### Updated Behavior
`_.debounce` is no longer used to create a function for saving annotations. Instead, `saveLabelAnnotations` checks some state of the backbone view to determine what to do. If `isSaving === false`, then a request will be made to save annotations that are queued for save. Upon returning from the server, if there are any annotations that were queued up for save while work was being done on the server, another request will be made.

Also, now only the annotation that has its data changed will be queued for a save. If the categories change, all annotations will be saved with the updated categories.
