### PR TITLE
Add support for hotkeys beyond 9

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -25,6 +25,9 @@ export default Vue.extend({
             return _.filter(store.categories, (category) => {
                 return category.label !== 'default';
             });
+        },
+        hotkeys() {
+            return store.hotkeys;
         }
     },
     mounted() {
@@ -37,11 +40,11 @@ export default Vue.extend({
     },
     methods: {
         keydownListener(event) {
-            // If support for > 9 categories is necessary, this will
-            // need to be revisited. Perhaps a map from event.key to
-            // category index could replace the simple parseInt call.
-            if (!isNaN(parseInt(event.key))) {
-                store.lastCategorySelected = parseInt(event.key);
+            // In order to accommodate more than 9 categories we index into the
+            // pre-defined list of hotkeys to map a key to each category
+            const idx = this.hotkeys.findIndex((k) => event.key === k);
+            if (idx !== -1) {
+                store.lastCategorySelected = idx;
                 return;
             }
             switch (event.key) {
@@ -91,7 +94,7 @@ export default Vue.extend({
         :key="category.label"
         class="h-hotkey"
       >
-        {{ index + 1 }} - {{ category.label }}
+        {{ hotkeys[index + 1] }} - {{ category.label }}
       </span>
     </div>
   </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/constants.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/constants.js
@@ -1,0 +1,11 @@
+/**
+ * Provide an extended list of default hotkeys. By default zero will be the
+ * "reset" option and 1 through 9 will represent the first 9 categories. After
+ * that the hotkeys follow the standard QWERTY keyboard layout, row by row.
+ */
+export const hotkeys = [
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p',
+    'a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l',
+    'z', 'x', 'c', 'v', 'b', 'n', 'm'
+];

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/store.js
@@ -1,5 +1,7 @@
 import Vue from 'vue';
 
+import { hotkeys as hotkeysConst } from './constants';
+
 const store = Vue.observable({
     selectedIndex: 0,
     page: 0,
@@ -14,7 +16,8 @@ const store = Vue.observable({
     predictions: false,
     currentAverageCertainty: 0,
     categories: [],
-    lastCategorySelected: null
+    lastCategorySelected: null,
+    hotkeys: hotkeysConst
 });
 
 const previousCard = () => {


### PR DESCRIPTION
This simply adds support for hotkey bindings beyond 9 categories. Zero still defaults to being the "reset" option, and 1 through 9 still represent the first 9 categories. After that the hotkeys follow the standard QWERTY keyboard layout, row by row.

I did try to research a little bit but as far as I can tell there is no "standard"/"best" hotkey priority ordering, but if I am mistaken or there are other preferences on order I am happy to make changes!

Addresses part of #70 