### PR TITLE
Allow users to edit hotkeys

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -3,7 +3,8 @@ import Vue from 'vue';
 
 import _ from 'underscore';
 
-import { store, previousCard, nextCard } from './store.js';
+import { comboHotkeys } from './constants';
+import { store, previousCard, nextCard, assignHotkey } from './store.js';
 
 import MouseAndKeyboardControls from '../MouseAndKeyboardControls.vue';
 
@@ -13,7 +14,9 @@ export default Vue.extend({
     },
     data() {
         return {
-            showShortcuts: true
+            showShortcuts: true,
+            currentlyEditing: '',
+            currentInput: []
         };
     },
     computed: {
@@ -28,6 +31,19 @@ export default Vue.extend({
         },
         hotkeys() {
             return store.hotkeys;
+        },
+        editMode: {
+            get() {
+                return store.editingHotkeys;
+            },
+            set(mode) {
+                store.editingHotkeys = mode;
+            }
+        }
+    },
+    watch: {
+        editMode(editing) {
+            if (!editing) this.resetEditingValues();
         }
     },
     mounted() {
@@ -39,10 +55,18 @@ export default Vue.extend({
         store.lastCategorySelected = null;
     },
     methods: {
-        keydownListener(event) {
-            // In order to accommodate more than 9 categories we index into the
-            // pre-defined list of hotkeys to map a key to each category
-            const idx = this.hotkeys.findIndex((k) => event.key === k);
+        parseUserHotkeys(event) {
+            // Combine the list of selected keys
+            const pressed = _.filter(comboHotkeys, (key) => event[`${key}Key`]);
+            if (!(event.key in pressed)) pressed.push(event.key);
+            return pressed;
+        },
+        categoryKeydownListener(event) {
+            // Using hotkeys to select categories
+            // In order to accommodate more than 9 categories map default and
+            // user-defined hotkeys to each category index
+            const userHotkeys = this.parseUserHotkeys(event);
+            const idx = this.hotkeys.get(userHotkeys.join('+'));
             if (idx !== -1) {
                 store.lastCategorySelected = idx;
                 return;
@@ -55,6 +79,47 @@ export default Vue.extend({
                     previousCard();
                     break;
             }
+        },
+        editKeydownListener(event) {
+            // Using keyboard to set hotkeys
+            if (event.key === 'Enter') {
+                // The user has finalized their hotkey selection
+                const newKey = this.currentInput.join('+');
+                assignHotkey(this.currentlyEditing, newKey);
+                this.resetEditingValues();
+                return;
+            }
+            this.currentInput = this.parseUserHotkeys(event);
+        },
+        keydownListener(event) {
+            event.preventDefault();
+            if (this.editMode) {
+                this.editKeydownListener(event);
+            } else {
+                this.categoryKeydownListener(event);
+            }
+        },
+        resetEditingValues() {
+            this.currentlyEditing = '';
+            this.currentInput = [];
+        },
+        hotkeyFromIndex(index) {
+            return _.find([...this.hotkeys], ([, v]) => v === index)[0];
+        },
+        editHotkey(index) {
+            const hotkey = this.hotkeyFromIndex(index);
+            if (this.currentlyEditing) {
+                // We're editing a new key, reset what we were working on
+                this.resetEditingValues();
+            }
+            this.currentlyEditing = hotkey;
+        },
+        editModeText(index) {
+            const hotkey = this.hotkeyFromIndex(index);
+            if (this.currentlyEditing === hotkey) {
+                return this.currentInput.join('+') || 'Editing';
+            }
+            return hotkey;
         }
     }
 });
@@ -87,15 +152,62 @@ export default Vue.extend({
       <span class="h-hotkey">
         Left Arrow - Previous Superpixel
       </span>
-      <h6>Labeling</h6>
-      <span class="h-hotkey">0 - Reset selection</span>
-      <span
-        v-for="(category, index) in nonDefaultCategories"
-        :key="category.label"
-        class="h-hotkey"
+      <div class="h-hotkeys-header">
+        <h6>Labeling</h6>
+        <button
+          class="h-hotkeys-toggle"
+          @click="editMode = !editMode"
+        >
+          <i
+            v-if="editMode"
+            class="icon-ok"
+          />
+          <i
+            v-else
+            class="icon-pencil"
+          />
+        </button>
+      </div>
+      <p
+        v-if="editMode"
+        class="h-hotkeys-edit-subtitle"
       >
-        {{ hotkeys[index + 1] }} - {{ category.label }}
-      </span>
+        Click on a hotkey to edit. Press enter to accept change.
+      </p>
+      <div v-if="editMode">
+        <span class="h-hotkey">
+          <button
+            class="h-hotkey-edit-button"
+            @click="() => editHotkey(0)"
+          >
+            {{ editModeText(0) }}
+          </button>
+          <span> - Reset Selection</span>
+        </span>
+        <span
+          v-for="(category, index) in nonDefaultCategories"
+          :key="category.label"
+          class="h-hotkey"
+        >
+          <button
+            class="h-hotkey-edit-button"
+            @click="() => editHotkey(index + 1)"
+          >
+            {{ editModeText(index + 1) }}
+          </button>
+          <span> - {{ category.label }}</span>
+        </span>
+      </div>
+      <div v-else>
+        <span class="h-hotkey">{{ hotkeyFromIndex(0) }} - Reset selection</span>
+        <span
+          v-for="(category, index) in nonDefaultCategories"
+          :key="category.label"
+          class="h-hotkey"
+        >
+          {{ hotkeyFromIndex(index + 1) }} - {{ category.label }}
+        </span>
+      </div>
     </div>
   </div>
 </template>
@@ -133,5 +245,17 @@ export default Vue.extend({
 
 .h-bindings {
     font-size: 12px;
+}
+
+.h-hotkey-edit-button {
+    width: 40%;
+    font-size: smaller;
+    border: ridge;
+    background-color: transparent;
+}
+
+.h-hotkeys-edit-subtitle {
+    font-size: x-small;
+    font-style: italic;
 }
 </style>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -67,7 +67,7 @@ export default Vue.extend({
             // user-defined hotkeys to each category index
             const userHotkeys = this.parseUserHotkeys(event);
             const idx = this.hotkeys.get(userHotkeys.join('+'));
-            if (idx !== -1) {
+            if (!_.isUndefined(idx)) {
                 store.lastCategorySelected = idx;
                 return;
             }
@@ -82,9 +82,16 @@ export default Vue.extend({
         },
         editKeydownListener(event) {
             // Using keyboard to set hotkeys
+            const newKey = this.currentInput.join('+');
+            const assignedHotkeys = _.filter(this.hotkeys, (_key, idx) => {
+                return idx < this.categories.length;
+            });
+            if (newKey in assignedHotkeys ||
+                  (event.key === 'Enter' && this.currentlyEditing !== -1)) {
+                event.preventDefault();
+            }
             if (event.key === 'Enter') {
                 // The user has finalized their hotkey selection
-                const newKey = this.currentInput.join('+');
                 const hotKey = this.hotkeyFromIndex(this.currentlyEditing);
                 assignHotkey(hotKey, newKey);
                 this.resetEditingValues();
@@ -93,7 +100,6 @@ export default Vue.extend({
             this.currentInput = this.parseUserHotkeys(event);
         },
         keydownListener(event) {
-            event.preventDefault();
             if (this.editMode) {
                 this.editKeydownListener(event);
             } else {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -15,7 +15,7 @@ export default Vue.extend({
     data() {
         return {
             showShortcuts: true,
-            currentlyEditing: '',
+            currentlyEditing: -1,
             currentInput: []
         };
     },
@@ -85,7 +85,8 @@ export default Vue.extend({
             if (event.key === 'Enter') {
                 // The user has finalized their hotkey selection
                 const newKey = this.currentInput.join('+');
-                assignHotkey(this.currentlyEditing, newKey);
+                const hotKey = this.hotkeyFromIndex(this.currentlyEditing);
+                assignHotkey(hotKey, newKey);
                 this.resetEditingValues();
                 return;
             }
@@ -100,26 +101,24 @@ export default Vue.extend({
             }
         },
         resetEditingValues() {
-            this.currentlyEditing = '';
+            this.currentlyEditing = -1;
             this.currentInput = [];
         },
         hotkeyFromIndex(index) {
             return _.find([...this.hotkeys], ([, v]) => v === index)[0];
         },
         editHotkey(index) {
-            const hotkey = this.hotkeyFromIndex(index);
-            if (this.currentlyEditing) {
+            if (this.currentlyEditing >= 0) {
                 // We're editing a new key, reset what we were working on
                 this.resetEditingValues();
             }
-            this.currentlyEditing = hotkey;
+            this.currentlyEditing = index;
         },
         editModeText(index) {
-            const hotkey = this.hotkeyFromIndex(index);
-            if (this.currentlyEditing === hotkey) {
+            if (this.currentlyEditing === index) {
                 return this.currentInput.join('+') || 'Editing';
             }
-            return hotkey;
+            return this.hotkeyFromIndex(index);
         }
     }
 });
@@ -178,6 +177,7 @@ export default Vue.extend({
         <span class="h-hotkey">
           <button
             class="h-hotkey-edit-button"
+            :style="[currentlyEditing === 0 && {'font-style': 'italic'}]"
             @click="() => editHotkey(0)"
           >
             {{ editModeText(0) }}
@@ -191,6 +191,7 @@ export default Vue.extend({
         >
           <button
             class="h-hotkey-edit-button"
+            :style="[currentlyEditing === (index + 1) && {'font-style': 'italic'}]"
             @click="() => editHotkey(index + 1)"
           >
             {{ editModeText(index + 1) }}

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/constants.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/constants.js
@@ -9,3 +9,8 @@ export const hotkeys = [
     'a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l',
     'z', 'x', 'c', 'v', 'b', 'n', 'm'
 ];
+
+/**
+ * List of options that can be combined with hotkeys to create new bindings
+ */
+export const comboHotkeys = ['ctrl', 'shift', 'alt'];

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/store.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 
-import { hotkeys as hotkeysConst } from './constants';
+import _ from 'underscore';
+
+import { hotkeys as hotkeysConsts } from './constants';
 
 const store = Vue.observable({
     selectedIndex: 0,
@@ -17,7 +19,8 @@ const store = Vue.observable({
     currentAverageCertainty: 0,
     categories: [],
     lastCategorySelected: null,
-    hotkeys: hotkeysConst
+    hotkeys: new Map(_.map(hotkeysConsts, (k, i) => [k, i])),
+    editingHotkeys: false
 });
 
 const previousCard = () => {
@@ -40,8 +43,21 @@ const nextCard = () => {
     }
 };
 
+const assignHotkey = (oldkey, newKey) => {
+    // Check for duplicate key bindings
+    const oldVal = store.hotkeys.get(newKey);
+    store.hotkeys.set(newKey, store.hotkeys.get(oldkey)).delete(oldkey);
+    if (!_.isNull(oldVal)) {
+        // Key was already assigned an index.
+        // Update that index to an unused value.
+        const idx = _.findIndex(hotkeysConsts, (k) => !store.hotkeys.has(k));
+        store.hotkeys.set(hotkeysConsts[idx], oldVal);
+    }
+};
+
 export {
     store,
     nextCard,
-    previousCard
+    previousCard,
+    assignHotkey
 };


### PR DESCRIPTION
This branch adds support for user edits to hotkeys.

1. To start editing, select the pencil icon button. The view will update to be editable. Current hotkeys will not work (categories cannot be set while in edit mode).
2. To change a key binding, click the key assignment you'd like to change. Select the key or key combination you'd prefer and the current key text will be updated.
    1. To accept the change, press enter.
    2. To discard the change:
        1. Click the selection again -OR-
        2. Click the check mark to close edit mode without pressing enter -OR-
        3. Select another key assignment without pressing enter
3. When you're done with the new assignments, click the check mark to exit the edit mode. Hotkeys for category selection is enabled again.

![edit_hotkeys](https://github.com/DigitalSlideArchive/wsi-superpixel-guided-labeling/assets/51238406/2227f760-2666-4fa4-ae12-e3fbf7419ab4)

Some questions/concerns:
- Possible workflow change: I am a little concerned that the current workflow (mouse click(edit mode) -> mouse click(select item to edit) -> enter key(accept change)) may be a bit clunky. This can be re-worked (click again to accept and a button or other option to reset/discard?) or if it's not too annoying for now this can always be revisited with the future UI improvements.
- Assignment Conflicts: Right now conflicting assignments are automatically corrected. If preferred we can skip the step of automatically correcting and instead just warn users and prevent accepting changes until corrections are made. Example of current approach:
    - Given hotkeys `[1, 2, 3, 4]` and categories `[category_a, category_b]`, default assignment is `{1: category_a, 2: category_b}`.
    - User assigns key `2` to `category_a`. `category_b` is automatically updated to the first unused hotkey (in this case that is now `1`).
- Possibly too much freedom: Users have a lot of freedom in designing key bindings. Do we want to limit this?

~Should be rebased on #75 before merge~ :white_check_mark: Rebased
Closes #70 