### PR TITLE
Add slider for annotation opacity

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
@@ -9,7 +9,7 @@ import ActiveLearningFilmStrip from './ActiveLearningFilmStrip.vue';
 import ActiveLearningKeyboardShortcuts from './ActiveLearningKeyboardShortcuts.vue';
 import AnnotationOpacityControl from '../AnnotationOpacityControl.vue';
 
-import { store, synchronizeCategories, saveAnnotations, updatePixelmapLayerStyle } from '../store.js';
+import { store, updatePixelmapLayerStyle } from '../store.js';
 
 export default Vue.extend({
     components: {
@@ -209,13 +209,11 @@ export default Vue.extend({
                 this.drawLabels();
             });
             this.viewerWidget.on('g:drawOverlayAnnotation', (element, layer) => {
-                if (element.type === 'pixelmap') this.overlayLayer = layer;
+                if (element.type === 'pixelmap') {
+                    this.overlayLayer = layer;
+                    updatePixelmapLayerStyle(layer);
+                }
             });
-        },
-        synchronizeCategories() {
-            synchronizeCategories();
-            saveAnnotations(this.selectedImageId);
-            updatePixelmapLayerStyle(this.overlayLayer);
         }
     }
 });
@@ -226,7 +224,7 @@ export default Vue.extend({
     <active-learning-keyboard-shortcuts />
     <annotation-opacity-control
       :active-learning-setup="false"
-      :update="synchronizeCategories"
+      :overlay-layer="overlayLayer"
     />
     <div
       ref="map"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
@@ -9,7 +9,7 @@ import ActiveLearningFilmStrip from './ActiveLearningFilmStrip.vue';
 import ActiveLearningKeyboardShortcuts from './ActiveLearningKeyboardShortcuts.vue';
 import AnnotationOpacityControl from '../AnnotationOpacityControl.vue';
 
-import { store } from './store.js';
+import { store } from '../store.js';
 
 export default Vue.extend({
     components: {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -3,7 +3,7 @@ import _ from 'underscore';
 
 import ActiveLearningFilmStripCard from './ActiveLearningFilmStripCard.vue';
 import ActiveLearningStats from './ActiveLearningStats.vue';
-import { store } from './store.js';
+import { store } from '../store.js';
 
 export default {
     components: {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -2,7 +2,7 @@
 import Vue from 'vue';
 import _ from 'underscore';
 
-import { store, nextCard } from './store';
+import { store, nextCard } from '../store';
 
 export default Vue.extend({
     props: ['index'],

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -4,7 +4,7 @@ import Vue from 'vue';
 import _ from 'underscore';
 
 import { comboHotkeys } from './constants';
-import { store, previousCard, nextCard, assignHotkey } from './store.js';
+import { store, previousCard, nextCard, assignHotkey } from '../store.js';
 
 import MouseAndKeyboardControls from '../MouseAndKeyboardControls.vue';
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningStats.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningStats.vue
@@ -1,5 +1,5 @@
 <script>
-import { store } from './store.js';
+import { store } from '../store.js';
 
 export default {
     data() {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -480,6 +480,8 @@ export default Vue.extend({
           <annotation-opacity-control
             :active-learning-setup="true"
             :update="synchronizeCategories"
+            :category-index="categoryIndex"
+            :fill-color="currentCategoryFillColor"
           />
         </div>
       </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -6,6 +6,7 @@ import { restRequest } from '@girder/core/rest';
 import { ViewerWidget } from '@girder/large_image_annotation/views';
 import ColorPickerInput from '@girder/histomicsui/vue/components/ColorPickerInput.vue';
 
+import AnnotationOpacityControl from '../AnnotationOpacityControl.vue';
 import MouseAndKeyboardControls from '../MouseAndKeyboardControls.vue';
 
 // Define some helpful constants for adding categories
@@ -21,7 +22,8 @@ const colorPattern = /^(#[0-9a-fA-F]{3,4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}|rgb\(\
 export default Vue.extend({
     components: {
         ColorPickerInput,
-        MouseAndKeyboardControls
+        MouseAndKeyboardControls,
+        AnnotationOpacityControl
     },
     props: ['backboneParent', 'imageNamesById', 'annotationsByImageId'],
     data() {
@@ -498,6 +500,11 @@ export default Vue.extend({
               {{ imageNamesById[imageId] }}
             </option>
           </select>
+          <annotation-opacity-control
+            :active-learning-setup="true"
+            :categories="allNewCategories"
+            :update="synchronizeCategories"
+          />
         </div>
       </div>
       <div
@@ -542,7 +549,7 @@ export default Vue.extend({
     border: 1px solid #f0f0f0;
 }
 .h-al-image-selector {
-    display: block;
+    display: flex;
     padding-top: 8px;
 }
 .h-form-controls {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -489,7 +489,7 @@ export default Vue.extend({
           <annotation-opacity-control
             :active-learning-setup="true"
             :fill-color="currentCategoryFillColor"
-            :overlay-layer="overlayLayer"
+            :overlay-layers="[overlayLayer]"
           />
         </div>
       </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
@@ -1,12 +1,19 @@
 <script>
 import _ from 'underscore';
 
+import { store } from './store.js';
+
 export default {
-    props: ['activeLearningSetup', 'categories', 'update'],
+    props: ['activeLearningSetup', 'update'],
     data() {
         return {
             opacitySlider: 1.0
         };
+    },
+    computed: {
+        categories() {
+            return store.categories;
+        }
     },
     watch: {
         opacitySlider(opacity) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
@@ -4,7 +4,7 @@ import _ from 'underscore';
 import { store } from './store.js';
 
 export default {
-    props: ['activeLearningSetup', 'update'],
+    props: ['activeLearningSetup', 'update', 'categoryIndex', 'fillColor'],
     data() {
         return {
             opacitySlider: 1.0
@@ -18,16 +18,21 @@ export default {
     watch: {
         opacitySlider(opacity) {
             _.map(this.categories, (cat) => {
-                const newColor = this.rgbStringToArray(cat.strokeColor);
-                cat.strokeColor = `rgba(${newColor}, ${opacity})`;
+                if (parseFloat(opacity) === 0) {
+                    // If opacity is zero, fill color and stroke color should be the same
+                    cat.strokeColor = cat.fillColor;
+                } else {
+                    // Use the default stroke color value
+                    cat.strokeColor = `rgba(${[0, 0, 0]}, ${opacity})`;
+                }
                 return cat;
             });
             this.update();
-        }
-    },
-    methods: {
-        rgbStringToArray(rgbStr) {
-            return rgbStr.match(/\d+(?:\.\d+)?/g).map(Number).slice(0, 3);
+        },
+        fillColor(color) {
+            if (parseFloat(this.opacitySlider) === 0) {
+                this.categories[this.categoryIndex].strokeColor = color;
+            }
         }
     }
 };

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
@@ -5,7 +5,7 @@ import { restRequest } from '@girder/core/rest';
 import { store, updatePixelmapLayerStyle } from './store.js';
 
 export default {
-    props: ['activeLearningSetup', 'fillColor', 'overlayLayer'],
+    props: ['activeLearningSetup', 'fillColor', 'overlayLayers'],
     data() {
         return {
             config: null
@@ -30,11 +30,11 @@ export default {
     watch: {
         opacitySlider() {
             this.updateConfigData();
-            updatePixelmapLayerStyle(this.overlayLayer);
+            updatePixelmapLayerStyle(this.overlayLayers);
         },
         fillColor() {
             if (this.opacitySlider === 0) {
-                updatePixelmapLayerStyle(this.overlayLayer);
+                updatePixelmapLayerStyle(this.overlayLayers);
             }
         },
         folderId: {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
@@ -1,0 +1,72 @@
+<script>
+import _ from 'underscore';
+
+export default {
+    props: ['activeLearningSetup', 'categories', 'update'],
+    data() {
+        return {
+            opacitySlider: 1.0
+        };
+    },
+    watch: {
+        opacitySlider(opacity) {
+            _.map(this.categories, (cat) => {
+                const newColor = this.rgbStringToArray(cat.strokeColor);
+                cat.strokeColor = `rgba(${newColor}, ${opacity})`;
+                return cat;
+            });
+            this.update();
+        }
+    },
+    methods: {
+        rgbStringToArray(rgbStr) {
+            return rgbStr.match(/\d+(?:\.\d+)?/g).map(Number).slice(0, 3);
+        }
+    }
+};
+</script>
+
+<template>
+  <div :class="{'h-opacity-slider-setup-container': activeLearningSetup, 'h-opacity-slider-learning-container': !activeLearningSetup}">
+    <span class="h-opacity-slider-label">Superpixel Boundary Opacity:</span>
+    <input
+      v-model="opacitySlider"
+      class="h-opacity-slider"
+      type="range"
+      min="0"
+      max="1"
+      step="0.01"
+    >
+  </div>
+</template>
+
+<style scoped>
+.h-opacity-slider-learning-container {
+    z-index: 1000;
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    padding: 5px;
+    min-width: 200px;
+    display: flex;
+    background-color: white;
+    border-radius: 1px;
+    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.5);
+}
+
+.h-opacity-slider-setup-container {
+    width: 100%;
+    margin: 0px 5px;
+    display: flex;
+    justify-content: center;
+}
+
+.h-opacity-slider-label {
+    min-width: fit-content;
+}
+
+.h-opacity-slider {
+    width: 75%;
+    margin-left: 5px;
+}
+</style>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -54,11 +54,51 @@ const assignHotkey = (oldkey, newKey) => {
         const idx = _.findIndex(hotkeysConsts, (k) => !store.hotkeys.has(k));
         store.hotkeys.set(hotkeysConsts[idx], oldVal);
     }
+}
+
+/**
+ * Ensure that the label and prediction annotations are drawn correctly by
+ * keeping the geojs layer up to date with the most recent category list
+ */
+const updatePixelmapLayerStyle = (overlayLayer) => {
+    _.forEach(overlayLayer.features(), (feature) => {
+        feature.style('color', (d, i) => {
+            if (d < 0 || d >= store.categories.length) {
+                console.warn(`No category found at index ${d} in the category map.`);
+                return 'rgba(0, 0, 0, 0)';
+            }
+            const category = store.categories[d];
+            return (i % 2 === 0) ? category.fillColor : category.strokeColor;
+        });
+    });
+    overlayLayer.draw();
+};
+
+const saveAnnotations = (imageId) => {
+    // If we dont specify an image, save all images
+    const idsToSave = imageId ? [imageId] : Object.keys(store.annotationsByImageId);
+    store.backboneParent.saveLabelAnnotations(idsToSave);
+};
+
+const synchronizeCategories = () => {
+    _.forEach(Object.values(store.annotationsByImageId), (annotations) => {
+        _.forEach(['predictions', 'labels'], (key) => {
+            if (annotations[key]) {
+                const superpixelElement = annotations[key].get('annotation').elements[0];
+                if (superpixelElement) {
+                    superpixelElement.categories = JSON.parse(JSON.stringify(store.categories));
+                }
+            }
+        });
+    });
 };
 
 export {
     store,
     nextCard,
     previousCard,
-    assignHotkey
+    assignHotkey,
+    synchronizeCategories,
+    saveAnnotations,
+    updatePixelmapLayerStyle
 };

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -60,25 +60,27 @@ const assignHotkey = (oldkey, newKey) => {
  * Ensure that the label and prediction annotations are drawn correctly by
  * keeping the geojs layer up to date with the most recent category list
  */
-const updatePixelmapLayerStyle = (overlayLayer) => {
-    if (!overlayLayer) {
+const updatePixelmapLayerStyle = (overlayLayers) => {
+    if (!overlayLayers.length) {
         return;
     }
 
-    _.forEach(overlayLayer.features(), (feature) => {
-        feature.style('color', (d, i) => {
-            if (d < 0 || d >= store.categories.length) {
-                console.warn(`No category found at index ${d} in the category map.`);
-                return 'rgba(0, 0, 0, 0)';
-            }
-            const category = store.categories[d];
-            // If opacity is zero, fill color and stroke color should be the same
-            let strokeColor = `rgba(${[0, 0, 0]}, ${store.strokeOpacity})`;
-            strokeColor = store.strokeOpacity ? strokeColor : category.fillColor;
-            return (i % 2 === 0) ? category.fillColor : strokeColor;
+    _.forEach(overlayLayers, (overlayLayer) => {
+        _.forEach(overlayLayer.features(), (feature) => {
+            feature.style('color', (d, i) => {
+                if (d < 0 || d >= store.categories.length) {
+                    console.warn(`No category found at index ${d} in the category map.`);
+                    return 'rgba(0, 0, 0, 0)';
+                }
+                const category = store.categories[d];
+                // If opacity is zero, fill color and stroke color should be the same
+                let strokeColor = `rgba(${[0, 0, 0]}, ${store.strokeOpacity})`;
+                strokeColor = store.strokeOpacity ? strokeColor : category.fillColor;
+                return (i % 2 === 0) ? category.fillColor : strokeColor;
+            });
         });
+        overlayLayer.draw();
     });
-    overlayLayer.draw();
 };
 
 export {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 
 import _ from 'underscore';
 
-import { hotkeys as hotkeysConsts } from './constants';
+import { hotkeys as hotkeysConsts } from './ActiveLearning/constants';
 
 const store = Vue.observable({
     selectedIndex: 0,
@@ -20,7 +20,8 @@ const store = Vue.observable({
     categories: [],
     lastCategorySelected: null,
     hotkeys: new Map(_.map(hotkeysConsts, (k, i) => [k, i])),
-    editingHotkeys: false
+    editingHotkeys: false,
+    opacity: 1.0
 });
 
 const previousCard = () => {


### PR DESCRIPTION
This adds an opacity slider to the setup and training steps that allows users to change the opacity of the superpixel boundaries.

![setup_opacity](https://github.com/DigitalSlideArchive/wsi-superpixel-guided-labeling/assets/51238406/88afa4dd-10bf-41a2-8ee8-917011ab57ab)

https://github.com/DigitalSlideArchive/wsi-superpixel-guided-labeling/assets/51238406/3148758f-00fd-48dd-85ff-ee166cdb0929
