### PR TITLE
Improved category selection

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningContainer.vue
@@ -226,7 +226,6 @@ export default Vue.extend({
   <div class="h-active-learning-container">
     <active-learning-keyboard-shortcuts />
     <annotation-opacity-control
-      :active-learning-setup="false"
       :overlay-layers="overlayLayers"
     />
     <div

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -133,7 +133,10 @@ export default Vue.extend({
 
 <template>
   <div class="h-hotkeys-container">
-    <mouse-and-keyboard-controls :active-learning-setup="false" />
+    <mouse-and-keyboard-controls
+      :active-learning-setup="false"
+      :pixelmap-paint-brush="false"
+    />
     <div class="h-hotkeys-header">
       <h5>Hotkeys</h5>
       <button

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/constants.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/constants.js
@@ -14,3 +14,20 @@ export const hotkeys = [
  * List of options that can be combined with hotkeys to create new bindings
  */
 export const comboHotkeys = ['ctrl', 'shift', 'alt'];
+
+/**
+ * Default colors for new categories from the d3 tableau10 scheme.
+ * https://d3js.org/d3-scale-chromatic/categorical#schemeTableau10
+ */
+export const schemeTableau10 = [
+    '#4e79a7',
+    '#f28e2c',
+    '#e15759',
+    '#76b7b2',
+    '#59a14f',
+    '#edc949',
+    '#af7aa1',
+    '#ff9da7',
+    '#9c755f',
+    '#bab0ab'
+];

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -302,7 +302,8 @@ export default Vue.extend({
             if (
                 overlayElement.get('type') !== 'pixelmap' || // Not a pixelmap event
                 !event.mouse.buttonsDown.left || // Not a left click
-                !this.currentCategoryFormValid // no valid category selected
+                !this.currentCategoryFormValid || // no valid category selected
+                (this.pixelmapPaintBrush && event.mouse.modifiers.shift)
             ) {
                 return;
             }
@@ -345,7 +346,7 @@ export default Vue.extend({
             let newLabel = 0;
             const previousLabel = data[index];
             // the +1 accounts for the default, reset to default if already labeled with the selected category
-            if (event.event === geo.event.feature.mouseover || event.event === geo.event.feature.mousedown) {
+            if ((event.event === geo.event.feature.mouseover || event.event === geo.event.feature.mousedown)) {
                 newLabel = this.pixelmapPaintValue;
             } else if (event.event === geo.event.feature.mouseclick) {
                 newLabel = (previousLabel === this.categoryIndex + 1) ? 0 : this.categoryIndex + 1;
@@ -376,6 +377,7 @@ export default Vue.extend({
                 this.categories[this.categoryIndex].indices[this.currentImageId] = currentCategoryIndices;
             }
             if (newLabel === 0) {
+                this.categories[oldLabel - 1].indices[this.currentImageId].delete(elementValueIndex);
                 currentCategoryIndices.delete(elementValueIndex);
             } else if (oldLabel === 0) {
                 currentCategoryIndices.add(elementValueIndex);
@@ -384,8 +386,7 @@ export default Vue.extend({
                 currentCategoryIndices.add(elementValueIndex);
             }
             // Force computed properties to update
-            const newCategoryData = Object.assign({}, this.categories[this.categoryIndex]);
-            this.categories.splice(this.categoryIndex, 1, newCategoryData);
+            this.categories = [...this.categories];
         },
         /*************************
          * RESPOND TO USER INPUT *

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -585,30 +585,6 @@ export default Vue.extend({
                 </td>
               </tr>
             </table>
-            <div
-              class="h-error-messages"
-              v-if="!currentCategoryFormValid || !currentLabelsValid"
-            >
-              <p class="form-validation-error">
-                Please fix all errors to continue
-              </p>
-              <ul v-if="currentFormErrors.length > 0 || currentLabelingErrors.length > 0">
-                <li
-                  v-for="error in currentFormErrors"
-                  :key="error"
-                  class="form-validation-error"
-                >
-                  {{ error }}
-                </li>
-                <li
-                  v-for="error in currentLabelingErrors"
-                  :key="error"
-                  class="form-validation-error"
-                >
-                  {{ error }}
-                </li>
-              </ul>
-            </div>
           </div>
           <button
             class="btn btn-info btn-block"
@@ -618,6 +594,30 @@ export default Vue.extend({
             <i class="icon-plus" /> Add Category
           </button>
         </div>
+      </div>
+      <div
+        v-if="!currentCategoryFormValid || !currentLabelsValid"
+        class="h-error-messages"
+      >
+        <p class="form-validation-error">
+          Please fix all errors to continue
+        </p>
+        <ul v-if="currentFormErrors.length > 0 || currentLabelingErrors.length > 0">
+          <li
+            v-for="error in currentFormErrors"
+            :key="error"
+            class="form-validation-error"
+          >
+            {{ error }}
+          </li>
+          <li
+            v-for="error in currentLabelingErrors"
+            :key="error"
+            class="form-validation-error"
+          >
+            {{ error }}
+          </li>
+        </ul>
       </div>
       <hr v-if="showLabelingContainer" />
       <button
@@ -778,7 +778,8 @@ tr:hover .editing-icons {
 }
 
 .h-error-messages {
-  padding-top: 25px;
+    padding-top: 25px;
+    height: 100%;
 }
 
 .form-validation-error {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -458,9 +458,9 @@ export default Vue.extend({
             this.updateConfig();
         },
         mergeCategory(newLabel, newFillColor) {
-            newLabel = this.enforceUniqueName(newLabel);
-            this.addCategory(newLabel, newFillColor);
+            this.addCategory('Merged Categories', newFillColor);
             this.combineCategories(this.checkedCategories, true);
+            _.last(this.categories).category.label = this.enforceUniqueName(newLabel);
         },
         deleteCategory(indices) {
             const labelCounts = _.reduce([...this.selectedLabels.values()], (acc, selected) => {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -384,11 +384,14 @@ export default Vue.extend({
         /*************************
          * RESPOND TO USER INPUT *
          *************************/
-        addCategory() {
+        addCategory(newName) {
+            if (_.isUndefined(newName)) {
+                newName = 'New Category';
+            }
             const nextColor = this.getFillColor(this.categories.length);
             this.categories.push({
                 category: {
-                    label: 'New Category',
+                    label: this.enforceUniqueName(newName),
                     fillColor: nextColor,
                     strokeColor: boundaryColor
                 },
@@ -424,6 +427,15 @@ export default Vue.extend({
             const hexColor = schemeTableau10[index % 10];
             const [r, g, b] = hexColor.slice(1).match(/.{1,2}/g);
             return `rgba(${parseInt(r, 16)}, ${parseInt(g, 16)}, ${parseInt(b, 16)}, 0.5)`;
+        },
+        enforceUniqueName(name) {
+            const existingNames = _.map(this.categories, (category) => category.category.label);
+            let count = 1;
+            let uniqueName = name;
+            while (_.some(existingNames, (en) => en.includes(uniqueName)) && count < 50) {
+                uniqueName = `${name} (${count++})`;
+            }
+            return uniqueName;
         },
         /**********************************
          * USE BACKBONE CONTAINER METHODS *
@@ -589,7 +601,7 @@ export default Vue.extend({
           <button
             class="btn btn-info btn-block"
             :disabled="!currentCategoryFormValid"
-            @click="addCategory"
+            @click="() => addCategory()"
           >
             <i class="icon-plus" /> Add Category
           </button>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -752,6 +752,7 @@ export default Vue.extend({
       <mouse-and-keyboard-controls
         v-if="showInfoContainer"
         :active-learning-setup="true"
+        :pixelmap-paint-brush="pixelmapPaintBrush"
       />
       <i class="icon-info-circled" />
       <button

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -481,6 +481,14 @@ export default Vue.extend({
                 confirmCallback: () => this.combineCategories(indices, false)
             });
         },
+        togglePicker(event, index) {
+            const picker = this.$refs.colorpicker[index];
+            const colorPicker = picker.$refs.colorPicker;
+            if (event.target.className === 'current-color' && colorPicker) {
+                // Default to th RGBA input
+                colorPicker.fieldsIndex++;
+            }
+        },
         /***********
          * UTILITY *
          ***********/
@@ -657,9 +665,13 @@ export default Vue.extend({
                   </div>
                 </td>
                 <td>{{ labeledSuperpixelCounts[key].count }}</td>
-                <td>
+                <td
+                  id="colorPickerInput"
+                  @click="(e) => togglePicker(e, index)"
+                >
                   <color-picker-input
                     :key="key"
+                    ref="colorpicker"
                     v-model="currentCategoryFillColor"
                     class="condensed-color-picker"
                     :color="labeledSuperpixelCounts[key].fillColor"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -8,12 +8,11 @@ import ColorPickerInput from '@girder/histomicsui/vue/components/ColorPickerInpu
 
 import AnnotationOpacityControl from '../AnnotationOpacityControl.vue';
 import MouseAndKeyboardControls from '../MouseAndKeyboardControls.vue';
-import { comboHotkeys } from '../ActiveLearning/constants.js';
+import { comboHotkeys, schemeTableau10 } from '../ActiveLearning/constants.js';
 import { store, updatePixelmapLayerStyle } from '../store.js';
 
 // Define some helpful constants for adding categories
 const boundaryColor = 'rgba(0, 0, 0, 1)';
-const defaultNewCategoryColor = 'rgba(255, 0, 0, 0.5)';
 const defaultCategory = {
     label: 'default',
     fillColor: 'rgba(0, 0, 0, 0)',
@@ -39,7 +38,7 @@ export default Vue.extend({
             categories: [],
             categoryIndex: 0,
             currentCategoryLabel: 'New Category',
-            currentCategoryFillColor: defaultNewCategoryColor,
+            currentCategoryFillColor: this.getFillColor(0),
 
             // keep track of the current image and annotation to edit
             currentImageId: '',
@@ -236,10 +235,11 @@ export default Vue.extend({
                 this.createCategoriesFromPixelmapElement(pixelmapElement, imageId, existingCategories);
             });
             if (this.categories.length === 0) {
+                const fillColor = this.getFillColor(this.categories.length);
                 this.categories.push({
                     category: {
                         label: 'New Category',
-                        fillColor: defaultNewCategoryColor,
+                        fillColor,
                         strokeColor: boundaryColor
                     },
                     indices: {}
@@ -385,10 +385,11 @@ export default Vue.extend({
          * RESPOND TO USER INPUT *
          *************************/
         addCategory() {
+            const nextColor = this.getFillColor(this.categories.length);
             this.categories.push({
                 category: {
                     label: 'New Category',
-                    fillColor: defaultNewCategoryColor,
+                    fillColor: nextColor,
                     strokeColor: boundaryColor
                 },
                 indices: {}
@@ -418,6 +419,11 @@ export default Vue.extend({
                 updatePixelmapLayerStyle([this.overlayLayer]);
                 this.updateConfig();
             }
+        },
+        getFillColor(index) {
+            const hexColor = schemeTableau10[index % 10];
+            const [r, g, b] = hexColor.slice(1).match(/.{1,2}/g);
+            return `rgba(${parseInt(r, 16)}, ${parseInt(g, 16)}, ${parseInt(b, 16)}, 0.5)`;
         },
         /**********************************
          * USE BACKBONE CONTAINER METHODS *

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -127,7 +127,11 @@ export default Vue.extend({
             this.categories[this.categoryIndex].category.fillColor = this.currentCategoryFillColor;
             this.synchronizeCategories();
         },
-        categoryIndex() {
+        categoryIndex(index) {
+            if (index < 0 || index >= this.categories.length) {
+                this.categoryIndex = 0;
+                return;
+            }
             this.currentCategoryLabel = this.categories[this.categoryIndex].category.label;
             this.currentCategoryFillColor = this.categories[this.categoryIndex].category.fillColor;
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -628,7 +628,7 @@ export default Vue.extend({
                 :class="{'h-selected-row': categoryIndex === index}"
                 @click="categoryIndex = index"
               >
-                <td>{{ hotkeyFromIndex(index) }}</td>
+                <td>{{ hotkeyFromIndex(index + 1) }}</td>
                 <td
                   v-if="editing === index"
                   class="table-labels"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -457,6 +457,15 @@ export default Vue.extend({
             this.combineCategories(this.checkedCategories, true);
         },
         deleteCategory(indices) {
+            const noLabels = _.every(indices, (i) => {
+                const label = this.categories[i].category.label;
+                return this.labeledSuperpixelCounts[`${i}_${label}`].counts === 0;
+            });
+            if (noLabels) {
+                // If nothing was labeled we don't need a warning dialog
+                this.combineCategories(indices, false);
+                return;
+            }
             confirm({
                 title: 'Warning',
                 text: 'Deleting categories cannot be undone. Are you sure you want to continue?',
@@ -637,14 +646,6 @@ export default Vue.extend({
                     >
                       <i class="icon-pencil" />
                     </button>
-                    <button
-                      class="btn h-table-button"
-                      data-toggle="tooltip"
-                      title="Delete category"
-                      @click="() => deleteCategory([index])"
-                    >
-                      <i class="icon-trash" />
-                    </button>
                   </div>
                 </td>
                 <td>{{ labeledSuperpixelCounts[key].count }}</td>
@@ -669,16 +670,13 @@ export default Vue.extend({
             </table>
             <div class="h-remove-categories">
               <button
-                class="btn btn-warning btn-xs"
-                :disabled="checkedCategories.length < 2"
-                data-toggle="modal"
-                data-target="#mergeConfirmation"
+                class="btn btn-danger btn-xs"
+                :disabled="checkedCategories.length < 1"
+                data-toggle="tooltip"
+                title="Delete category"
+                @click="() => deleteCategory(checkedCategories)"
               >
-                <i
-                  class="icon-resize-small"
-                  data-toggle="tooltip"
-                  title="Merge selected categories"
-                />
+                <i class="icon-trash" />
               </button>
               <button
                 class="btn btn-warning btn-xs"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -570,7 +570,7 @@ export default Vue.extend({
             title="Left-click + drag to paint"
             @click="pixelmapPaintBrush = !pixelmapPaintBrush"
           >
-            <i class="icon-brush" />
+            <i class="icon-paint-roller" />
           </button>
         </div>
       </div>
@@ -685,7 +685,7 @@ export default Vue.extend({
                 data-target="#mergeConfirmation"
               >
                 <i
-                  class="icon-resize-small"
+                  class="icon-merge-rows"
                   data-toggle="tooltip"
                   title="Merge selected categories"
                 />

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningMergeConfirmation.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningMergeConfirmation.vue
@@ -1,0 +1,103 @@
+<script>
+import Vue from 'vue';
+
+import ColorPickerInput from '@girder/histomicsui/vue/components/ColorPickerInput.vue';
+
+export default Vue.extend({
+    components: {
+        ColorPickerInput
+    },
+    props: ['callback', 'categoryName', 'fillColor'],
+    data() {
+        return {
+            currentCategoryLabel: 'Merged Categories',
+            currentCategoryFillColor: 'rgba(0, 0, 0, 0.5)',
+            newFillColor: 'rgba(0, 0, 0, 0.5)'
+        };
+    },
+    watch: {
+        categoryName(name) {
+            this.currentCategoryLabel = name;
+        },
+        fillColor(color) {
+            this.newFillColor = color;
+            this.currentCategoryFillColor = color;
+        }
+    },
+    methods: {
+        submit() {
+            this.callback(this.currentCategoryLabel, this.currentCategoryFillColor);
+        }
+    }
+});
+</script>
+
+<template>
+  <div
+    class="modal fade"
+    role="dialog"
+  >
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button
+            type="button"
+            class="close"
+            data-dismiss="modal"
+          >
+            &times;
+          </button>
+          <h4 class="modal-title">
+            Merge Categories
+          </h4>
+        </div>
+        <div class="modal-body">
+          <p> WARNING: Merging categories cannot be undone. </p>
+          <div class="form-group h-form-inputs">
+            <label for="usr">New Name:</label>
+            <input
+              id="category-label"
+              v-model="currentCategoryLabel"
+              class="form-control category-input"
+            >
+            <color-picker-input
+              :key="fillColor"
+              v-model="currentCategoryFillColor"
+              class="condensed-color-picker"
+              :color="newFillColor"
+            />
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button
+            type="button"
+            class="btn btn-default"
+            data-dismiss="modal"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn btn-danger"
+            data-dismiss="modal"
+            @click="submit"
+          >
+            Merge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.h-form-inputs {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-evenly;
+}
+
+.category-input {
+    width: 35%;
+}
+</style>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningMergeConfirmation.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningMergeConfirmation.vue
@@ -1,5 +1,6 @@
 <script>
 import Vue from 'vue';
+import _ from 'underscore';
 
 import ColorPickerInput from '@girder/histomicsui/vue/components/ColorPickerInput.vue';
 
@@ -7,13 +8,25 @@ export default Vue.extend({
     components: {
         ColorPickerInput
     },
-    props: ['callback', 'categoryName', 'fillColor'],
+    props: ['callback', 'categoryName', 'fillColor', 'selectedLabels'],
     data() {
         return {
             currentCategoryLabel: 'Merged Categories',
             currentCategoryFillColor: 'rgba(0, 0, 0, 0.5)',
             newFillColor: 'rgba(0, 0, 0, 0.5)'
         };
+    },
+    computed: {
+        warningMessage() {
+            const numCategories = this.selectedLabels.size;
+            const labelCounts = _.reduce([...this.selectedLabels.values()], (acc, selected) => {
+                return acc + selected.count;
+            }, 0);
+            const message = `This will combine ${numCategories} categories into
+                          one category containing all ${labelCounts} labeled
+                          superpixels.`;
+            return message;
+        }
     },
     watch: {
         categoryName(name) {
@@ -52,7 +65,7 @@ export default Vue.extend({
           </h4>
         </div>
         <div class="modal-body">
-          <p> WARNING: Merging categories cannot be undone. </p>
+          <p> WARNING: Merging categories cannot be undone. {{ warningMessage }} </p>
           <div class="form-group h-form-inputs">
             <label for="usr">New Name:</label>
             <input

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
@@ -4,7 +4,7 @@ import _ from 'underscore';
 import { store, updatePixelmapLayerStyle } from './store.js';
 
 export default {
-    props: ['activeLearningSetup', 'fillColor', 'overlayLayers'],
+    props: ['fillColor', 'overlayLayers'],
     computed: {
         config() {
             if (store.backboneParent) {
@@ -67,7 +67,7 @@ export default {
 </script>
 
 <template>
-  <div :class="{'h-opacity-slider-setup-container': activeLearningSetup, 'h-opacity-slider-learning-container': !activeLearningSetup}">
+  <div class="h-opacity-slider-learning-container">
     <span class="h-opacity-slider-label">Superpixel Boundary Opacity:</span>
     <input
       v-model="opacitySlider"
@@ -92,13 +92,6 @@ export default {
     background-color: white;
     border-radius: 1px;
     box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.5);
-}
-
-.h-opacity-slider-setup-container {
-    width: 100%;
-    margin: 0px 5px;
-    display: flex;
-    justify-content: center;
 }
 
 .h-opacity-slider-label {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/MouseAndKeyboardControls.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/MouseAndKeyboardControls.vue
@@ -17,7 +17,10 @@ export default Vue.extend({
 
 <template>
   <div :class="{'h-controls-container': activeLearningSetup}">
-    <div class="h-controls-header">
+    <div
+      v-if="!activeLearningSetup"
+      class="h-controls-header"
+    >
       <h5>Mouse and Keyboard Controls</h5>
       <button
         class="h-controls-toggle"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/MouseAndKeyboardControls.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/MouseAndKeyboardControls.vue
@@ -2,7 +2,7 @@
 import Vue from 'vue';
 
 export default Vue.extend({
-    props: ['activeLearningSetup'],
+    props: ['activeLearningSetup', 'pixelmapPaintBrush'],
     data() {
         return {
             showControls: true
@@ -44,16 +44,30 @@ export default Vue.extend({
         v-if="activeLearningSetup"
         class="h-controls"
       >
-        <li>Left-click: Label single superpixel</li>
-        <li>Shift-left-drag: Continuously label superpixels</li>
+        <li>Left-click: Label/unlabel single superpixel</li>
+        <li v-if="pixelmapPaintBrush">
+          Left-drag: Continuously label/unlabel superpixels
+        </li>
+        <li v-else>
+          Shift-left-drag: Continuously label/unlabel superpixels
+        </li>
       </ul>
       <h6>Pan</h6>
       <ul class="h-controls">
-        <li>Left-drag</li>
-        <li>Middle-drag: This works even when editing annotations.</li>
-        <li>Single touch drag</li>
+        <li v-if="pixelmapPaintBrush">
+          Shift-left-drag
+        </li>
+        <li v-else>
+          Left-drag
+        </li>
+        <li v-if="!pixelmapPaintBrush">
+          Middle-drag: This works even when editing annotations.
+        </li>
+        <li v-if="!pixelmapPaintBrush">
+          Single touch drag
+        </li>
         <li v-if="activeLearningSetup">
-          Arrow keys / Shift-arrow keys / Shift-ctrl-arrow keys
+          Arrow keys / Shift-arrow keys
         </li>
       </ul>
       <h6>Zoom</h6>
@@ -62,12 +76,8 @@ export default Vue.extend({
         <li>Mouse wheel</li>
         <li>Multi-touch spread or contract</li>
         <li v-if="activeLearningSetup">
-          Plus, minus / Shift-plus, shift-minus / Shift-ctrl-plus, shift-ctrl-minus
+          Plus, minus / Shift-plus, shift-minus
         </li>
-        <li v-if="activeLearningSetup">
-          1 - 7: The number keys 1 - 7 will zoom to discrete zoom levels.
-        </li>
-        <li>Shift-left-drag, shift-right-drag: Zoom into or out of the selected rectangle</li>
       </ul>
       <h6>Rotate</h6>
       <ul class="h-controls">
@@ -76,9 +86,6 @@ export default Vue.extend({
         <li>Multi-touch rotate</li>
         <li v-if="activeLearningSetup">
           &lt;, &gt; (also . or ,) rotate the image a small amount. If shift is held down, &lt; and &gt; rotate the image 90 degrees.
-        </li>
-        <li v-if="activeLearningSetup">
-          0: 0 returns the image to the default orientation.
         </li>
       </ul>
     </div>


### PR DESCRIPTION
This PR addresses a handful of issues:

- Category management has now been moved to a floating dialog
- No longer requires using "previous" and "next" to move between categories. Instead categories can now be selected by clicking on their row in the table.
- On hover over a row a pencil icon is shown. Clicking the pencil will enable editing the category name. When editing is complete this can be indicated with the enter key or using the checkmark to the right of the input.
- Selecting the colored square for that row opens the dialog to change the category color. This change does remove the inline input that supports typing in the `rgba` value but this can still be entered in the pop-up dialog.

![rgba_color](https://github.com/DigitalSlideArchive/wsi-superpixel-guided-labeling/assets/51238406/29a66b7d-a4b0-4143-b779-cf3fb7d6309e)

- Categories can be deleted by selecting one or more checkboxes and using the trash icon at the bottom of the table.
- Selecting two or more categories with the checkboxes enables the "merge categories" button. Categories that are merged will create a new name (for example `foo` and `bar` become `Merged-foo_bar`) and new category color, all of which can be edited inline in the table like other categories.
- Hotkeys can be used to automatically select the category that you are labeling with.
- The default behavior for labeling is the same (shift+left-click to continuously label, left-click+drag to pan) but selecting the paint brush icon inverts this behavior (shift+left-click to pan, left-click+drag to continuously label).
- The color for a new category no longer defaults to red but instead cycles through the [d3 tableau 10 scheme](https://d3js.org/d3-scale-chromatic/categorical#schemeTableau10).
- Each new category created now has a unique name (for example, if "New Category" aready exists, "New Category (1)" will be created next). This means that users can now quickly add many categories and then edit instead of being forced to edit each new category before being able to add another.

Depends on girder/girder#3506
Closes #31, #69, #30, and #53