### PR TITLE
Remove keydown listener if already set

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -51,6 +51,11 @@ export default Vue.extend({
     },
     mounted() {
         store.lastCategorySelected = null;
+        // FIXME: Occasionally the container is mounted twice and not destroyed
+        // which results in events triggering the keydown listener more than
+        // once. If we can reproduce more consistently we should fix the real
+        // issue. For now just make sure we're not registering the same listener twice.
+        window.removeEventListener('keydown', this.keydownListener);
         window.addEventListener('keydown', this.keydownListener);
     },
     destroyed() {


### PR DESCRIPTION
Occasionally the container is mounted twice but not destroyed, and this results in keydown events triggering the listener more than once.

Unfortunately I have been unable to reproduce this consistently in order to fix the real underlying issue. For now we just unregister the keydown listener before registering it. If it has not yet been registered nothing will happen, but if it has we will prevent registering it twice.

Fixes #94 