### PR TITLE
Do not cut off film strip items on small screen

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -79,11 +79,16 @@ export default {
     >
       <i class="icon-left-circled h-filmstrip-page-icon" />
     </button>
-    <active-learning-film-strip-card
-      v-for="superpixel, index in superpixelsToDisplay"
-      :key="`${superpixel.imageId}_${superpixel.index}`"
-      :index="index"
-    />
+    <div
+      id="filmstrip-cards"
+      class="h-filmstrip-cards"
+    >
+      <active-learning-film-strip-card
+        v-for="superpixel, index in superpixelsToDisplay"
+        :key="`${superpixel.imageId}_${superpixel.index}`"
+        :index="index"
+      />
+    </div>
     <button
       class="h-filmstrip-page-btn h-filmstrip-page-btn--next btn"
       :disabled="page === maxPage"
@@ -142,6 +147,12 @@ export default {
     top: 8px;
     color: white;
     left: 15px;
+}
+
+.h-filmstrip-cards {
+    display: flex;
+    width: 85%;
+    justify-content: space-evenly;
 }
 
 .h-filmstrip-page-btn {


### PR DESCRIPTION
Wrap cards so that they are not cut off in small screens

![resize_filmstrip](https://github.com/DigitalSlideArchive/wsi-superpixel-guided-labeling/assets/51238406/e21a37a7-c620-4b7b-ac0a-facfc863da80)

Fixes #104 