### PR TITLE
Simplify inputs

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -669,9 +669,11 @@ const ActiveLearningView = View.extend({
                     if (goToNextStep) {
                         // We might need to go back to the server for more data
                         this.checkJobs();
+                    } else {
+                        // We're all done, grab the results
+                        this.lastRunJobId = jobId;
+                        this.getAnnotations();
                     }
-                    this.lastRunJobId = jobId;
-                    this.getAnnotations();
                 }
                 // TODO handle job failure
             });

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningKeyboardShortcuts.vue
@@ -47,11 +47,6 @@ export default Vue.extend({
     },
     mounted() {
         store.lastCategorySelected = null;
-        // FIXME: Occasionally the container is mounted twice and not destroyed
-        // which results in events triggering the keydown listener more than
-        // once. If we can reproduce more consistently we should fix the real
-        // issue. For now just make sure we're not registering the same listener twice.
-        window.removeEventListener('keydown', this.keydownListener);
         window.addEventListener('keydown', this.keydownListener);
     },
     destroyed() {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -649,6 +649,7 @@ export default Vue.extend({
                     v-model="currentCategoryLabel"
                     class="form-control input-sm category-input"
                     @keyup.enter="editing = -1"
+                    @blur="editing = -1"
                   >
                   <button
                     class="btn h-table-button"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialLabels.vue
@@ -145,8 +145,16 @@ export default Vue.extend({
             this.superpixelAnnotation = this.annotationsByImageId[this.currentImageId].labels;
             this.setupViewer();
         },
-        pixelmapPaintBrush(activated) {
+        pixelmapPaintBrush() {
             this.updateActionModifiers();
+        },
+        editing() {
+            if (this.editing === -1) {
+                return;
+            }
+            const key = `label_${this.editing}`;
+            console.log('editing: ', key, this.$refs, this.$refs[key]);
+            this.$nextTick(() => this.$refs[key][0].focus());
         }
     },
     mounted() {
@@ -646,10 +654,12 @@ export default Vue.extend({
                 >
                   <input
                     id="category-label"
+                    :ref="`label_${index}`"
                     v-model="currentCategoryLabel"
                     class="form-control input-sm category-input"
                     @keyup.enter="editing = -1"
                     @blur="editing = -1"
+                    @focus="$event.target.select()"
                   >
                   <button
                     class="btn h-table-button"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -20,7 +20,6 @@ const store = Vue.observable({
     categories: [],
     lastCategorySelected: null,
     hotkeys: new Map(_.map(hotkeysConsts, (k, i) => [k, i])),
-    editingHotkeys: false,
     strokeOpacity: 1.0
 });
 


### PR DESCRIPTION
This further simplifies editing hotkeys and label names:
1. Hotkeys can now be edited with a single click. Changes are automatically accepted without further prompts/clicks. Clicking away from the text will exit the edit mode.

![simple_hotkey_edit](https://github.com/DigitalSlideArchive/wsi-superpixel-guided-labeling/assets/51238406/29c1af5b-bb84-4473-8533-be9552063afc)

2. Editing label names can now also be completed by clicking outside of the input.

![accept_on_blur](https://github.com/DigitalSlideArchive/wsi-superpixel-guided-labeling/assets/51238406/fec07553-1e2e-4efa-9e99-2a9a0803c2b0)


Fixes #103 