### PR TITLE
Bump the z-index value for the filmstrip

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -159,7 +159,7 @@ export default {
     padding-top: 35px;
     padding-bottom: 10px;
     background-color: rgba(0, 0, 0, 0.6);
-    z-index: 50;
+    z-index: 100;
 }
 
 .h-filmstrip-cards {


### PR DESCRIPTION
It is possible to occasionally end up in a situation where the annotations layer overlaps the filmstrip. I was unable to reproduce, but in @jagstein's example none of the other dialogs were covered. Bumps the z-index to match the others to avoid this issue.

Fixes #126 