### PR TITLE
Mosaic improvements

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -104,7 +104,10 @@ export default Vue.extend({
       <select
         class="categories-selector"
       >
-        <option :value="null" :disabled="!superpixel.reviewCategory">
+        <option
+          :value="null"
+          :disabled="!superpixel.reviewCategory"
+        >
           {{ !superpixel.reviewCategory ? '' : 'Clear Review' }}
         </option>
         <option

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -85,11 +85,15 @@ export default Vue.extend({
         <img
           :src="wsiRegionUrl"
           loading="lazy"
+          :height="previewSize*100"
+          :width="previewSize*100"
         >
         <img
           class="h-superpixel-region"
           :src="superpixelRegionUrl"
           loading="lazy"
+          :height="previewSize*100"
+          :width="previewSize*100"
         >
       </button>
     </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -457,8 +457,12 @@ export default Vue.extend({
                   :key="key"
                 >
                   <div class="radio">
-                    <label class="options">
+                    <label
+                      :for="`${key}_group`"
+                      class="options"
+                    >
                       <input
+                        :id="`${key}_group`"
                         v-model="groupBy"
                         type="radio"
                         :value="parseInt(key)"
@@ -491,8 +495,12 @@ export default Vue.extend({
                   :key="key"
                 >
                   <div class="radio">
-                    <label class="options">
+                    <label
+                      :for="`${key}_sort`"
+                      class="options"
+                    >
                       <input
+                        :id="`${key}_sort`"
                         v-model="sortBy"
                         type="radio"
                         :value="parseInt(key)"
@@ -635,32 +643,60 @@ export default Vue.extend({
               :style="[dataSelectMenu ? {'display': 'flex'} : {'display': 'none'}]"
             >
               <li>
-                <input
-                  v-model="cardDetails"
-                  type="checkbox"
-                  value="selectedCategory"
-                >Class Name
+                <label
+                  for="className"
+                  class="checkboxLabel"
+                >
+                  <input
+                    id="className"
+                    v-model="cardDetails"
+                    type="checkbox"
+                    value="selectedCategory"
+                  >
+                  Class Name
+                </label>
               </li>
               <li>
-                <input
-                  v-model="cardDetails"
-                  type="checkbox"
-                  value="confidence"
-                >Confidence
+                <label
+                  for="confidence"
+                  class="checkboxLabel"
+                >
+                  <input
+                    id="confidence"
+                    v-model="cardDetails"
+                    type="checkbox"
+                    value="confidence"
+                  >
+                  Confidence
+                </label>
               </li>
               <li>
-                <input
-                  v-model="cardDetails"
-                  type="checkbox"
-                  value="certainty"
-                >Certainty
+                <label
+                  for="certainty"
+                  class="checkboxLabel"
+                >
+                  <input
+                    id="certainty"
+                    v-model="cardDetails"
+                    type="checkbox"
+                    value="certainty"
+                  >
+                  Certainty
+                </label>
               </li>
               <li>
-                <input
-                  v-model="cardDetails"
-                  type="checkbox"
-                  value="prediction"
-                >Prediction
+                <label
+                  for="prediction"
+                  class="checkboxLabel"
+                >
+                  <input
+                    id="prediction"
+                    v-model="cardDetails"
+                    type="checkbox"
+                    value="prediction"
+                  >
+                  Prediction
+                </label>
               </li>
             </ul>
           </div>
@@ -1057,5 +1093,10 @@ export default Vue.extend({
     width: 150px;
     padding: 5px;
     margin-bottom: 5px;
+}
+
+.checkboxLabel {
+  font-weight: normal;
+  vertical-align: middle;
 }
 </style>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -600,8 +600,8 @@ export default Vue.extend({
                 </optgroup>
               </select>
               <button
-                @click="filterBy = []"
                 :style="{'width': '36px'}"
+                @click="filterBy = []"
               >
                 <i
                   class="icon-ccw"
@@ -1093,31 +1093,31 @@ export default Vue.extend({
 }
 
 .flag {
-    background-color: #337ab7;
-    padding: 3px 3px 20px;
-    clip-path: polygon(0 0, 100% 0, 100% 50%, 50% 65%, 0 50%);
-    border-radius: 2px;
-    float: left;
-    width: 25px;
-    top: -2px;
+  background-color: #337ab7;
+  padding: 3px 3px 20px;
+  clip-path: polygon(0 0, 100% 0, 100% 50%, 50% 65%, 0 50%);
+  border-radius: 2px;
+  float: left;
+  width: 25px;
+  top: -2px;
 }
 
 .h-superpixel-card {
-    display: flex;
-    flex-direction: column;
-    background-color: white;
-    border-style: solid;
-    justify-content: center;
-    box-sizing: content-box;
-    border-width: 2px;
-    margin-bottom: 3px;
-    position: relative;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  border-style: solid;
+  justify-content: center;
+  box-sizing: content-box;
+  border-width: 2px;
+  margin-bottom: 3px;
+  position: relative;
 }
 
 .h-superpixel-card-detailed {
-    width: 150px;
-    padding: 5px;
-    margin-bottom: 5px;
+  width: 150px;
+  padding: 5px;
+  margin-bottom: 5px;
 }
 
 .checkboxLabel {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -486,10 +486,14 @@ export default Vue.extend({
                 <i
                   v-if="sortAscending"
                   class="icon-sort-alt-up"
+                  data-toggle="tooltip"
+                  title="Sort descending"
                 />
                 <i
                   v-else
                   class="icon-sort-alt-down"
+                  data-toggle="tooltip"
+                  title="Sort ascending"
                 />
               </button>
             </div>
@@ -504,11 +508,13 @@ export default Vue.extend({
             <div
               id="filterby"
               :style="{'position': 'relative'}"
+              class="dropdown sort-by-selector"
             >
               <button
                 class="btn btn-default dropdown-toggle drop-down-button"
                 type="button"
                 data-toggle="dropdown"
+                :style="{'width': 'calc(100% - 36px)'}"
               >
                 <span
                   class="filter-text"
@@ -539,6 +545,16 @@ export default Vue.extend({
                   </option>
                 </optgroup>
               </select>
+              <button
+                @click="filterBy = []"
+                :style="{'width': '36px'}"
+              >
+                <i
+                  class="icon-ccw"
+                  data-toggle="tooltip"
+                  title="Clear all filters"
+                />
+              </button>
             </div>
           </div>
         </div>
@@ -826,7 +842,6 @@ export default Vue.extend({
 
 .dropdown-menu-block {
   padding-left: 10px;
-  top: auto;
   min-height: 150px;
 }
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -90,8 +90,8 @@ export default Vue.extend({
         },
         filteredSortedGroupedSuperpixels() {
             let data = this.filterSuperpixels(this.superpixelsForReview);
-            data = this.sortSuperpixels(data);
-            return this.groupSuperpixels(data);
+            data = this.groupSuperpixels(data);
+            return _.mapObject(data, (value, key) => this.sortSuperpixels(value));
         },
         groupBy: {
             get() { return store.groupBy; },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -145,6 +145,24 @@ export default Vue.extend({
         });
         observer.observe(document.querySelector('.h-superpixel-card'));
 
+        // Make sure menus are always visible when opened
+        const menuObserver = new IntersectionObserver((entries, observer) => {
+            entries.forEach((entry) => {
+                const parent = entry.target.closest('.dropdown-dropup');
+                if (parent) {
+                    if (entry.isIntersecting) {
+                        const hidden = entry.rootBounds.bottom < entry.boundingClientRect.bottom;
+                        hidden ? parent.classList.add('dropup') : parent.classList.add('dropdown');
+                    } else {
+                        parent.classList.remove('dropdown', 'dropup');
+                    }
+                }
+            });
+        });
+        _.forEach(document.getElementsByClassName('dropdown-menu'), (element) => {
+            menuObserver.observe(element);
+        });
+
         this.selectedSuperpixel = this.filteredSortedGroupedSuperpixels.data[0];
         this.$nextTick(() => {
             const resizeHandle = document.querySelector('.resize-handle');
@@ -289,7 +307,10 @@ export default Vue.extend({
     class="v-row review-container"
   >
     <div class="resize-handle" />
-    <div class="col-sm-3 settings-panel">
+    <div
+      id="settingsPanel"
+      class="col-sm-3 settings-panel"
+    >
       <div class="panel panel-info">
         <div
           class="panel-heading collapsible"
@@ -420,7 +441,7 @@ export default Vue.extend({
             <label for="groupby">Group By</label>
             <div
               id="groupby"
-              class="dropdown"
+              class="dropdown-dropup"
             >
               <button
                 class="btn btn-block btn-default dropdown-toggle drop-down-button"
@@ -454,7 +475,7 @@ export default Vue.extend({
             <label for="sortby">Sort By</label>
             <div
               id="sortby"
-              class="dropdown sort-by-selector"
+              class="dropdown-dropup sort-by-selector"
             >
               <button
                 class="btn btn-block btn-default dropdown-toggle drop-down-button"
@@ -508,7 +529,7 @@ export default Vue.extend({
             <div
               id="filterby"
               :style="{'position': 'relative'}"
-              class="dropdown sort-by-selector"
+              class="dropdown-dropup sort-by-selector"
             >
               <button
                 class="btn btn-default dropdown-toggle drop-down-button"
@@ -699,7 +720,7 @@ export default Vue.extend({
             >
               Approve
             </button>
-            <div class="dropdown btn-group-two">
+            <div class="dropdown-dropup btn-group-two">
               <button
                 class="btn btn-primary dropdown-toggle btn-block"
                 :style="{'text-wrap': 'pretty'}"
@@ -838,6 +859,7 @@ export default Vue.extend({
 
 .dropdown-menu {
   width: 100%;
+  top: auto;
 }
 
 .dropdown-menu-block {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -248,7 +248,7 @@ export default Vue.extend({
                 return;
             }
             let superpixel = store.superpixelsToDisplay[store.selectedIndex];
-            if (store.mode === viewMode.Review) {
+            if (store.mode === viewMode.Review && store.reviewSuperpixel) {
                 superpixel = store.reviewSuperpixel;
             }
             if (store.currentImageId !== superpixel.imageId) {


### PR DESCRIPTION
Addresses the following issues:
- [x] Add a "clear all" option next to the filters menu
- [x] Scale images on preview size change to prevent older, larger previews extending outside of the individual chip space
- [x] When the "Change Class" dropdown is opened, make sure the menu is scrolled into view
- [x] Fix group + sort: changing sort should not re-order groups
- [x] Fix infinite scroll - does not behave properly if chips are first grouped and then scrolled
- [x] Fix checkbox select  - should select on text click, not just box click