### PR TITLE
Track user reviews

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -643,13 +643,14 @@ const ActiveLearningView = View.extend({
 
     applyReviews() {
         _.forEach(_.values(this.annotationsByImageId), (values) => {
-            const annotation = values.labels.get('annotation').labels;
+            const annotation = values.labels.get('annotation');
             if (annotation) {
-                _.forEach(Object.items(annotation.attributes.reviews), (v, k) => {
+                _.forEach(Object.entries(annotation.attributes.reviews), ([k, v]) => {
                     annotation.elements[0].values[k] = v.value;
                 });
             }
         });
+        this.saveAnnotations(Object.keys(this.annotationsByImageId));
     },
 
     retrain(goToNextStep) {

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -640,7 +640,9 @@ const ActiveLearningView = View.extend({
             const annotation = values.labels.get('annotation');
             if (annotation) {
                 _.forEach(Object.entries(annotation.attributes.metadata), ([k, v]) => {
-                    annotation.elements[0].values[k] = v.reviewValue;
+                    if (v.reviewValue && v.reviewEpoch >= v.labelEpoch) {
+                        annotation.elements[0].values[k] = v.reviewValue;
+                    }
                 });
             }
         });

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -640,7 +640,20 @@ const ActiveLearningView = View.extend({
         });
     },
 
+    applyReviews() {
+        _.forEach(_.values(this.annotationsByImageId), (values) => {
+            const annotation = values.labels.get('annotation').labels;
+            if (annotation) {
+                _.forEach(Object.items(annotation.attributes.reviews), (v, k) => {
+                    annotation.elements[0].values[k] = v.value;
+                });
+            }
+        });
+    },
+
     retrain(goToNextStep) {
+        // Apply any changes from reviews before retraining
+        this.applyReviews();
         // Make sure that our folder ids are up-to-date
         const data = this.generateClassificationJobData();
         data.jobId = this.lastRunJobId;

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -837,7 +837,7 @@ const ActiveLearningView = View.extend({
         restRequest({
             url: 'user/me'
         }).then((user) => {
-            store.currentUser = `${user.firstName} ${user.lastName}`;
+            store.currentUser = user;
             return store.currentUser;
         });
     }

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -520,7 +520,8 @@ const ActiveLearningView = View.extend({
                     predictionCategories: superpixelCategories,
                     labelCategories: labels.elements[0].categories,
                     selectedCategory: labelValues[index],
-                    reviewCategory: index in reviews ? reviews[index].value : undefined
+                    reviewCategory: index in reviews ? reviews[index].value : undefined,
+                    reviewer: index in reviews ? reviews[index].reviewer : undefined
                 };
                 this.superpixelPredictionsData.push(prediction);
             });

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -818,7 +818,6 @@ const ActiveLearningView = View.extend({
         }).then(() => {
             store.reviewedSuperpixels = _.reduce(_.values(this.annotationsByImageId), (acc, ann) => {
                 const attrs = ann.labels.get('annotation').attributes;
-                console.log(attrs.metadata);
                 return acc + _.size(_.pick(attrs.metadata, (v) => v.reviewEpoch === store.epoch));
             }, 0);
             return store.reviewedSuperpixels;

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -822,8 +822,9 @@ const ActiveLearningView = View.extend({
             contentType: 'application/json'
         }).then(() => {
             store.reviewedSuperpixels = _.reduce(_.values(this.annotationsByImageId), (acc, ann) => {
+                const dt = ann.labels.attributes.created;
                 const attrs = ann.labels.get('annotation').attributes;
-                return acc + _.size(attrs.reviews);
+                return acc + _.size(_.pick(attrs.reviews, (v, k) => v.date < dt));
             }, 0);
             return store.reviewedSuperpixels;
         });

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -66,8 +66,9 @@ export default {
         },
         agreeAll() {
             _.forEach(store.superpixelsToDisplay, (superpixel) => {
-                superpixel.selectedCategory = superpixel.prediction;
-                updateMetadata(superpixel, superpixel.prediction, false);
+                // Account for missing "default" category in predictions
+                superpixel.selectedCategory = superpixel.prediction + 1;
+                updateMetadata(superpixel, superpixel.prediction + 1, false);
             });
             store.backboneParent.saveAnnotationReviews(store.currentImageId);
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -5,6 +5,7 @@ import ActiveLearningFilmStripCard from './ActiveLearningFilmStripCard.vue';
 import ActiveLearningStats from './ActiveLearningStats.vue';
 import { store, updateSelectedPage } from '../store.js';
 import { viewMode } from '../constants';
+import { updateMetadata } from '../utils.js';
 
 export default {
     components: {
@@ -66,7 +67,7 @@ export default {
         agreeAll() {
             _.forEach(store.superpixelsToDisplay, (superpixel) => {
                 superpixel.selectedCategory = superpixel.prediction;
-                applyReview(superpixel, superpixel.prediction, false);
+                updateMetadata(superpixel, superpixel.prediction, false);
             });
             store.backboneParent.saveAnnotationReviews(store.currentImageId);
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -66,7 +66,9 @@ export default {
         agreeAll() {
             _.forEach(store.superpixelsToDisplay, (superpixel) => {
                 superpixel.selectedCategory = superpixel.prediction;
+                applyReview(superpixel, superpixel.prediction, false);
             });
+            store.backboneParent.saveAnnotationReviews(store.currentImageId);
         },
         resetAll() {
             _.forEach(store.superpixelsToDisplay, (superpixel) => {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -109,6 +109,9 @@ export default Vue.extend({
             if (newValue !== 0) {
                 store.categoriesAndIndices[newValue - 1].indices[this.imageId].add(index);
             }
+
+            applyReview(this.superpixelDecision, newValue, false);
+            store.backboneParent.saveAnnotationReviews(store.currentImageId);
             store.changeLog.push(this.superpixelDecision);
         },
         lastCategorySelected(categoryNumber) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -3,6 +3,7 @@ import Vue from 'vue';
 import _ from 'underscore';
 
 import { store, nextCard } from '../store';
+import { updateMetadata } from '../utils';
 
 export default Vue.extend({
     props: ['index'],
@@ -110,7 +111,7 @@ export default Vue.extend({
                 store.categoriesAndIndices[newValue - 1].indices[this.imageId].add(index);
             }
 
-            applyReview(this.superpixelDecision, newValue, false);
+            updateMetadata(this.superpixelDecision, newValue, false);
             store.backboneParent.saveAnnotationReviews(store.currentImageId);
             store.changeLog.push(this.superpixelDecision);
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -80,9 +80,7 @@ export default Vue.extend({
             immediate: true
         },
         sortedSuperpixelIndices() {
-            if (store.activeLearningStep >= activeLearningSteps.GuidedLabeling) {
-                updateSelectedPage();
-            }
+            updateSelectedPage();
         },
         mode() {
             if (store.mode === viewMode.Review) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -80,7 +80,9 @@ export default Vue.extend({
             immediate: true
         },
         sortedSuperpixelIndices() {
-            updateSelectedPage();
+            if (store.activeLearningStep >= activeLearningSteps.GuidedLabeling) {
+                updateSelectedPage();
+            }
         },
         mode() {
             if (store.mode === viewMode.Review) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -80,10 +80,6 @@ export default Vue.extend({
             immediate: true
         },
         sortedSuperpixelIndices() {
-            const startIndex = 0;
-            const endIndex = Math.min(startIndex + store.pageSize, store.sortedSuperpixelIndices.length);
-            store.superpixelsToDisplay = store.sortedSuperpixelIndices.slice(startIndex, endIndex);
-            store.maxPage = store.sortedSuperpixelIndices.length / store.pageSize;
             updateSelectedPage();
         },
         mode() {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -7,7 +7,7 @@ import ColorPickerInput from '@girder/histomicsui/vue/components/ColorPickerInpu
 
 import { store, assignHotkey, nextCard, previousCard } from './store.js';
 import { boundaryColor, comboHotkeys, viewMode, activeLearningSteps } from './constants.js';
-import { applyReview, getFillColor } from './utils.js';
+import { updateMetadata, getFillColor } from './utils.js';
 
 // Define some helpful constants for adding categories
 const defaultCategory = {
@@ -274,12 +274,12 @@ export default Vue.extend({
                         }
                         if (index in _.keys(meta) && meta[superpixel.index].reviewValue === oldValue) {
                             // A review is affected, update the metadata
-                            applyReview(superpixel, newValue + 1, true);
+                            updateMetadata(superpixel, newValue + 1, true);
                         }
                         if (labelIndices.has(index)) {
                             // A label is affected, update the value and the metadata
                             pixelmapElement.values[index] = (newValue + 1);
-                            applyReview(superpixel, newValue + 1, false);
+                            updateMetadata(superpixel, newValue + 1, false);
                         }
                     });
                 });
@@ -299,12 +299,12 @@ export default Vue.extend({
                         }
                         if (i in _.keys(meta) && meta[superpixel.index].reviewValue === oldValue) {
                             // A review is affected, update the metadata
-                            applyReview(superpixel, newValue, true);
+                            updateMetadata(superpixel, newValue, true);
                         }
                         if (labelIndices.has(i)) {
                             // A label is affected, update the value and the metadata
                             pixelmapElement.values[i] = newValue;
-                            applyReview(superpixel, newValue, false);
+                            updateMetadata(superpixel, newValue, false);
                         }
                     });
                     if (isMerge) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -552,10 +552,7 @@ export default Vue.extend({
                 </td>
                 <td v-else>
                   {{ hotkeyFromIndex(index + 1) }}
-                  <div
-                    v-if="mode !== viewMode.Review"
-                    class="editing-icons edit-hotkey"
-                  >
+                  <div class="editing-icons edit-hotkey">
                     <button
                       class="btn h-table-button"
                       data-toggle="tooltip"
@@ -594,10 +591,7 @@ export default Vue.extend({
                   :style="[mode === viewMode.Review && {'width': 'auto'}]"
                 >
                   {{ labeledSuperpixelCounts[key].label }}
-                  <div
-                    v-if="mode !== viewMode.Review"
-                    class="editing-icons"
-                  >
+                  <div class="editing-icons">
                     <button
                       class="btn h-table-button"
                       data-toggle="tooltip"
@@ -610,7 +604,6 @@ export default Vue.extend({
                 </td>
                 <td>{{ labeledSuperpixelCounts[key].count }}</td>
                 <td
-                  v-if="mode !== viewMode.Review"
                   id="colorPickerInput"
                   @click="(e) => togglePicker(e, index)"
                 >
@@ -622,12 +615,6 @@ export default Vue.extend({
                     :color="labeledSuperpixelCounts[key].fillColor"
                     data-toggle="tooltip"
                     title="Change label color"
-                  />
-                </td>
-                <td v-else>
-                  <i
-                    class="icon-stop"
-                    :style="[{'color': labeledSuperpixelCounts[key].fillColor}]"
                   />
                 </td>
                 <td v-if="mode === viewMode.Labeling">

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -5,7 +5,7 @@ import _ from 'underscore';
 import { store } from '../store';
 
 export default Vue.extend({
-    props: ['superpixel', 'previewSize', 'cardDetails', 'reviewCategory'],
+    props: ['superpixel', 'previewSize', 'cardDetails', 'reviewValue'],
     data() {
         return {
             override: false,
@@ -76,11 +76,11 @@ export default Vue.extend({
         },
         reviewed() {
             const reviews = this.getReviewInfo();
-            return !_.isNull(reviews[this.superpixel.index].value);
+            return !_.isNull(reviews[this.superpixel.index].reviewValue);
         },
         reviewerCategorySelection: {
             get() {
-                return this.superpixel.reviewCategory || this.superpixel.selectedCategory;
+                return this.superpixel.reviewValue || this.superpixel.selectedCategory;
             },
             set(newCategory) {
                 this.$emit('apply-review', this.superpixel, newCategory);
@@ -89,7 +89,7 @@ export default Vue.extend({
         }
     },
     watch: {
-        reviewCategory(newCategory, oldCategory) {
+        reviewValue(newCategory, oldCategory) {
             if (newCategory === oldCategory) {
                 return;
             }
@@ -99,7 +99,7 @@ export default Vue.extend({
     methods: {
         getReviewInfo() {
             const labels = store.annotationsByImageId[this.superpixel.imageId].labels;
-            return labels.get('annotation').attributes.reviews;
+            return labels.get('annotation').attributes.metadata;
         },
         formatValue(value) {
             if (value.toPrecision(4).length > value.toExponential(4).length) {
@@ -138,8 +138,8 @@ export default Vue.extend({
         v-model="reviewerCategorySelection"
         class="categories-selector"
       >
-        <option :value="!superpixel.reviewCategory ? 0 : null">
-          {{ !superpixel.reviewCategory ? 'Approve' : 'Clear Review' }}
+        <option :value="!superpixel.reviewValue ? 0 : null">
+          {{ !superpixel.reviewValue ? 'Approve' : 'Clear Review' }}
         </option>
         <option
           v-for="(category, index) in categories"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -100,9 +100,7 @@ export default Vue.extend({
         getReviewInfo() {
             const labels = store.annotationsByImageId[this.superpixel.imageId].labels;
             return labels.get('annotation').attributes.reviews;
-        }
-    },
-    methods: {
+        },
         formatValue(value) {
             if (value.toPrecision(4).length > value.toExponential(4).length) {
                 return value.toExponential(4);

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -3,6 +3,7 @@ import Vue from 'vue';
 import _ from 'underscore';
 
 import { store } from '../store';
+import { applyReview } from '../utils';
 
 export default Vue.extend({
     props: ['superpixel', 'previewSize', 'cardDetails', 'reviewValue'],
@@ -83,7 +84,7 @@ export default Vue.extend({
                 return this.superpixel.reviewValue || this.superpixel.selectedCategory;
             },
             set(newCategory) {
-                this.$emit('apply-review', this.superpixel, newCategory);
+                applyReview(this.superpixel, newCategory, true);
                 store.backboneParent.saveAnnotationReviews(this.superpixel.imageId);
             }
         }

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import _ from 'underscore';
 
 import { store } from '../store';
-import { applyReview } from '../utils';
+import { updateMetadata } from '../utils';
 
 export default Vue.extend({
     props: ['superpixel', 'previewSize', 'cardDetails', 'reviewValue'],
@@ -84,7 +84,7 @@ export default Vue.extend({
                 return this.superpixel.reviewValue || this.superpixel.selectedCategory;
             },
             set(newCategory) {
-                applyReview(this.superpixel, newCategory, true);
+                updateMetadata(this.superpixel, newCategory, true);
                 store.backboneParent.saveAnnotationReviews(this.superpixel.imageId);
             }
         }

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -344,7 +344,8 @@ export default Vue.extend({
                 reviews[superpixel.index] = {
                     reviewer: store.currentUser,
                     date: new Date().toDateString(),
-                    value: newCategory
+                    value: newCategory,
+                    epoch: store.epoch,
                 };
             }
             superpixel.reviewCategory = newCategory;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -132,7 +132,7 @@ export default Vue.extend({
             store.reviewSuperpixel = this.selectedSuperpixel || null;
         },
         filteredSortedGroupedSuperpixels(data) {
-            if (!!this.observedSuperpixel) {
+            if (this.observedSuperpixel) {
                 this.scrollObserver.unobserve(this.observedSuperpixel);
             }
             const filteredContainsSelected = _.findWhere(data, this.selectedSuperpixel);
@@ -363,11 +363,11 @@ export default Vue.extend({
             this.selectedReviewSuperpixels = _.union(..._.values(this.filteredSortedGroupedSuperpixels));
         },
         updateObserved() {
-            if (!!this.observedSuperpixel) {
+            if (this.observedSuperpixel) {
                 this.scrollObserver.unobserve(this.observedSuperpixel);
             }
             this.observedSuperpixel = _.last(document.getElementsByClassName('h-superpixel-card'));
-            if (!!this.observedSuperpixel) {
+            if (this.observedSuperpixel) {
                 this.scrollObserver.observe(this.observedSuperpixel);
             }
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -132,7 +132,7 @@ export default Vue.extend({
             store.reviewSuperpixel = this.selectedSuperpixel || null;
         },
         filteredSortedGroupedSuperpixels(data) {
-            if (!_.isNull(this.observedSuperpixel)) {
+            if (!!this.observedSuperpixel) {
                 this.scrollObserver.unobserve(this.observedSuperpixel);
             }
             const filteredContainsSelected = _.findWhere(data, this.selectedSuperpixel);
@@ -158,6 +158,7 @@ export default Vue.extend({
             rootMargin: '0px',
             threshold: 0.1
         });
+        this.updateObserved();
 
         // Make sure menus are always visible when opened
         const menuObserver = new IntersectionObserver((entries, observer) => {
@@ -281,7 +282,7 @@ export default Vue.extend({
             // Filter by selections that have not been reviewed
             if (store.filterBy.includes('no review')) {
                 results.push(_.filter(data, (superpixel) => {
-                    return _.isNull(superpixel.reiviewCategory);
+                    return _.isUndefined(superpixel.reviewCategory);
                 }));
             }
             const filtered = results.length ? _.intersection(...results) : data;
@@ -361,11 +362,13 @@ export default Vue.extend({
             this.selectedReviewSuperpixels = _.union(..._.values(this.filteredSortedGroupedSuperpixels));
         },
         updateObserved() {
-            if (!_.isNull(this.observedSuperpixel)) {
+            if (!!this.observedSuperpixel) {
                 this.scrollObserver.unobserve(this.observedSuperpixel);
             }
             this.observedSuperpixel = _.last(document.getElementsByClassName('h-superpixel-card'));
-            this.scrollObserver.observe(this.observedSuperpixel);
+            if (!!this.observedSuperpixel) {
+                this.scrollObserver.observe(this.observedSuperpixel);
+            }
         },
         reviewInfo() {
             if (!this.selectedSuperpixel) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -6,6 +6,7 @@ import ActiveLearningReviewCard from './ActiveLearningReviewCard.vue';
 import ActiveLearningLabeling from '../ActiveLearningLabeling.vue';
 import { store } from '../store.js';
 import { groupByOptions, sortByOptions } from '../constants';
+import { applyReview } from '../utils.js';
 
 export default Vue.extend({
     components: {
@@ -333,23 +334,9 @@ export default Vue.extend({
                 event.stopImmediatePropagation();
             }
         },
-        applyReview(superpixel, newValue) {
-            const labels = store.annotationsByImageId[superpixel.imageId].labels;
-            const meta = labels.get('annotation').attributes.metadata;
-            // If no new value is provided user selection is correct
-            const newCategory = newValue === 0 ? superpixel.selectedCategory : newValue;
-            meta[superpixel.index] = {
-                reviewer: store.currentUser,
-                reviewDate: new Date().toDateString(),
-                reviewValue: newCategory,
-                reviewEpoch: store.epoch
-            };
-            superpixel.reviewValue = newCategory;
-            superpixel.meta.reviewer = store.currentUser;
-        },
         applyBulkReview(newValue) {
             _.forEach(this.selectedReviewSuperpixels, (superpixel) => {
-                this.applyReview(superpixel, newValue);
+                applyReview(superpixel, newValue, true);
             });
             _.forEach(_.keys(store.annotationsByImageId),
                 (imageId) => store.backboneParent.saveAnnotationReviews(imageId));
@@ -964,7 +951,6 @@ export default Vue.extend({
                 data-toggle="modal"
                 data-target="#context"
                 @click.native="selectedSuperpixel = superpixel"
-                @apply-review="applyReview"
               />
               <div
                 v-if="!!superpixel.reviewValue"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -158,7 +158,6 @@ export default Vue.extend({
             rootMargin: '0px',
             threshold: 0.1
         });
-        this.scrollObserver.observe(document.querySelector('.h-superpixel-card'));
 
         // Make sure menus are always visible when opened
         const menuObserver = new IntersectionObserver((entries, observer) => {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -81,7 +81,7 @@ export default Vue.extend({
                 Slide: slides,
                 Label: categories,
                 Prediction: ['agree', 'disagree'],
-                Reviewed: ['reviewed', 'no review']
+                Reviewed: ['by me', 'by others', 'no review']
             };
         },
         imageItemsById() {
@@ -129,7 +129,7 @@ export default Vue.extend({
     },
     watch: {
         selectedSuperpixel() {
-            store.reviewSuperpixel = this.selectedSuperpixel;
+            store.reviewSuperpixel = this.selectedSuperpixel || null;
         },
         filteredSortedGroupedSuperpixels(data) {
             if (!_.isNull(this.observedSuperpixel)) {
@@ -267,16 +267,22 @@ export default Vue.extend({
                     return store.filterBy.includes(label);
                 }));
             }
-            // Filter by selections that have been reviewed
-            if (store.filterBy.includes('reviewed')) {
+            // Filter by selections that have been reviewed by current user
+            if (store.filterBy.includes('by me')) {
                 results.push(_.filter(data, (superpixel) => {
-                    return !_.isUndefined(superpixel.reviewCategory);
+                    return superpixel.reviewer === store.currentUser;
+                }));
+            }
+            // Filter by selections that have been reviewed by other users
+            if (store.filterBy.includes('by others')) {
+                results.push(_.filter(data, (superpixel) => {
+                    return !!superpixel.reviewer && superpixel.reviewer !== store.currentUser;
                 }));
             }
             // Filter by selections that have not been reviewed
             if (store.filterBy.includes('no review')) {
                 results.push(_.filter(data, (superpixel) => {
-                    return _.isUndefined(superpixel.reviewCategory);
+                    return _.isNull(superpixel.reiviewCategory);
                 }));
             }
             const filtered = results.length ? _.intersection(...results) : data;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -270,19 +270,19 @@ export default Vue.extend({
             // Filter by selections that have been reviewed by current user
             if (store.filterBy.includes('by me')) {
                 results.push(_.filter(data, (superpixel) => {
-                    return superpixel.reviewer === store.currentUser;
+                    return !!superpixel.reviewCategory && superpixel.reviewer._id === store.currentUser._id;
                 }));
             }
             // Filter by selections that have been reviewed by other users
             if (store.filterBy.includes('by others')) {
                 results.push(_.filter(data, (superpixel) => {
-                    return !!superpixel.reviewer && superpixel.reviewer !== store.currentUser;
+                    return !!superpixel.reviewCategory && superpixel.reviewer._id !== store.currentUser._id;
                 }));
             }
             // Filter by selections that have not been reviewed
             if (store.filterBy.includes('no review')) {
                 results.push(_.filter(data, (superpixel) => {
-                    return _.isUndefined(superpixel.reviewCategory);
+                    return !superpixel.reviewCategory;
                 }));
             }
             const filtered = results.length ? _.intersection(...results) : data;
@@ -348,6 +348,7 @@ export default Vue.extend({
                 };
             }
             superpixel.reviewCategory = newCategory;
+            superpixel.reviewer = store.currentUser;
         },
         applyBulkReview(newValue) {
             _.forEach(this.selectedReviewSuperpixels, (superpixel) => {
@@ -488,7 +489,7 @@ export default Vue.extend({
                 </tr>
                 <tr>
                   <td>Reviewer</td>
-                  <td>{{ reviewInfo().reviewer }}</td>
+                  <td>{{ reviewInfo().reviewer.firstName }} {{ reviewInfo().reviewer.lastName }}</td>
                 </tr>
                 <tr>
                   <td>Date</td>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -6,7 +6,7 @@ import ActiveLearningReviewCard from './ActiveLearningReviewCard.vue';
 import ActiveLearningLabeling from '../ActiveLearningLabeling.vue';
 import { store } from '../store.js';
 import { groupByOptions, sortByOptions } from '../constants';
-import { applyReview } from '../utils.js';
+import { updateMetadata } from '../utils.js';
 
 export default Vue.extend({
     components: {
@@ -336,7 +336,7 @@ export default Vue.extend({
         },
         applyBulkReview(newValue) {
             _.forEach(this.selectedReviewSuperpixels, (superpixel) => {
-                applyReview(superpixel, newValue, true);
+                updateMetadata(superpixel, newValue, true);
             });
             _.forEach(_.keys(store.annotationsByImageId),
                 (imageId) => store.backboneParent.saveAnnotationReviews(imageId));

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -7,7 +7,7 @@ import { ViewerWidget } from '@girder/large_image_annotation/views';
 
 import { activeLearningSteps, boundaryColor, viewMode } from './constants.js';
 import { store, updatePixelmapLayerStyle } from './store.js';
-import { applyReview, getFillColor } from './utils.js';
+import { updateMetadata, getFillColor } from './utils.js';
 
 export default Vue.extend({
     props: ['availableImages'],
@@ -441,7 +441,7 @@ export default Vue.extend({
                     index: boundaries ? index / 2 : index
                 };
             }
-            applyReview(superpixel, newLabel, false);
+            updateMetadata(superpixel, newLabel, false);
             store.backboneParent.saveAnnotationReviews(store.currentImageId);
 
             this.saveNewPixelmapData(boundaries, _.clone(data));

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -5,7 +5,7 @@ import _ from 'underscore';
 import { restRequest } from '@girder/core/rest';
 import { ViewerWidget } from '@girder/large_image_annotation/views';
 
-import { boundaryColor, viewMode } from './constants.js';
+import { activeLearningSteps, boundaryColor, viewMode } from './constants.js';
 import { store, updatePixelmapLayerStyle } from './store.js';
 import { applyReview, getFillColor } from './utils.js';
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -7,7 +7,7 @@ import { ViewerWidget } from '@girder/large_image_annotation/views';
 
 import { boundaryColor, viewMode } from './constants.js';
 import { store, updatePixelmapLayerStyle } from './store.js';
-import { getFillColor } from './utils.js';
+import { applyReview, getFillColor } from './utils.js';
 
 export default Vue.extend({
     props: ['availableImages'],
@@ -426,6 +426,23 @@ export default Vue.extend({
             const offset = boundaries ? 1 : 0;
             data[index] = data[index + offset] = newLabel;
             store.labelsOverlayLayer.indexModified(index, index + offset).draw();
+
+            let superpixel = {};
+            if (store.activeLearningStep >= activeLearningSteps.GuidedLabeling) {
+                superpixel = _.findWhere(store.sortedSuperpixelIndices, {
+                    index: boundaries ? index / 2 : index, imageId: store.currentImageId
+                });
+            } else {
+                // If we don't have predictions yet we don't have a list of
+                // superpixels. Build our own.
+                superpixel = {
+                    imageId: store.currentImageId,
+                    selectedCategory: newLabel,
+                    index: boundaries ? index / 2 : index
+                };
+            }
+            applyReview(superpixel, newLabel, false);
+            store.backboneParent.saveAnnotationReviews(store.currentImageId);
 
             this.saveNewPixelmapData(boundaries, _.clone(data));
             this.updateRunningLabelCounts(boundaries, index, newLabel, previousLabel);

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningToolBar.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningToolBar.vue
@@ -17,6 +17,9 @@ export default Vue.extend({
         },
         activeLearningSteps() {
             return activeLearningSteps;
+        },
+        reviewedSuperpixels() {
+            return store.reviewedSuperpixels;
         }
     },
     methods: {
@@ -62,6 +65,10 @@ export default Vue.extend({
         @click="changeMode(viewMode.Review)"
       >
         <i class="icon-th" /> Review
+        <span
+          v-if="reviewedSuperpixels > 0"
+          class="badge"
+        >{{ reviewedSuperpixels }}</span>
       </button>
     </div>
   </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -78,6 +78,10 @@ const nextCard = () => {
 };
 
 const updateSelectedPage = () => {
+    if (store.activeLearningStep < activeLearningSteps.GuidedLabeling) {
+        return;
+    }
+
     const startIndex = store.page * store.pageSize;
     const endIndex = Math.min(startIndex + store.pageSize, store.sortedSuperpixelIndices.length);
     store.superpixelsToDisplay = store.sortedSuperpixelIndices.slice(startIndex, endIndex);

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -23,6 +23,7 @@ const store = Vue.observable({
     center: { x: 1, y: 1 },
     sortedSuperpixelIndices: [],
     reviewSuperpixel: null,
+    currentUser: '',
     /*********
      * UI
      *********/
@@ -47,7 +48,8 @@ const store = Vue.observable({
     sortBy: 0,
     filterBy: [],
     previewSize: 0.5,
-    cardDetails: []
+    cardDetails: [],
+    reviewedSuperpixels: 0
 });
 
 const previousCard = () => {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -46,7 +46,7 @@ const store = Vue.observable({
     selectedReviewSuperpixels: [],
     groupBy: 0,
     sortBy: 0,
-    filterBy: [],
+    filterBy: ['no review'],
     previewSize: 0.5,
     cardDetails: [],
     reviewedSuperpixels: 0

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -24,6 +24,7 @@ const store = Vue.observable({
     sortedSuperpixelIndices: [],
     reviewSuperpixel: null,
     currentUser: null,
+    epoch: -1,
     /*********
      * UI
      *********/

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -23,7 +23,7 @@ const store = Vue.observable({
     center: { x: 1, y: 1 },
     sortedSuperpixelIndices: [],
     reviewSuperpixel: null,
-    currentUser: '',
+    currentUser: null,
     /*********
      * UI
      *********/

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -1,4 +1,5 @@
 import { schemeTableau10 } from './constants';
+import { store } from './store';
 
 /**
  * Find the default color given the index of an item. Uses the
@@ -21,4 +22,30 @@ export const getFillColor = (index) => {
  */
 export const rgbStringToArray = (rgbStr) => {
     return rgbStr.match(/\d+(?:\.\d+)?/g).map(Number);
+};
+
+/**
+ * Update the current epoch's label annotation metadata when a review or label
+ * has been set or changed.
+ *
+ * @param {object} superpixel The superpixel that has had its label or review set
+ * @param {int} newValue The new category that the review or label should be set to
+ * @param {boolean} isReview Whether or not this is a review. Will update the label if not a review.
+*/
+export const applyReview = (superpixel, newValue, isReview) => {
+    const labels = store.annotationsByImageId[superpixel.imageId].labels;
+    const meta = labels.get('annotation').attributes.metadata;
+    // If no new value is provided user selection is correct
+    const newCategory = newValue === 0 ? superpixel.selectedCategory : newValue;
+    const key = isReview ? 'review' : 'label';
+    superpixel.index in meta || (meta[superpixel.index] = {});
+    meta[superpixel.index][`${key}er`] = store.currentUser;
+    meta[superpixel.index][`${key}Date`] = new Date().toDateString();
+    meta[superpixel.index][`${key}Value`] = newCategory;
+    meta[superpixel.index][`${key}Epoch`] = store.epoch;
+
+    if (isReview) {
+        superpixel.reviewValue = newCategory;
+        superpixel.meta.reviewer = store.currentUser;
+    }
 };

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -32,7 +32,7 @@ export const rgbStringToArray = (rgbStr) => {
  * @param {int} newValue The new category that the review or label should be set to
  * @param {boolean} isReview Whether or not this is a review. Will update the label if not a review.
 */
-export const applyReview = (superpixel, newValue, isReview) => {
+export const updateMetadata = (superpixel, newValue, isReview) => {
     const labels = store.annotationsByImageId[superpixel.imageId].labels;
     const meta = labels.get('annotation').attributes.metadata;
     // If no new value is provided user selection is correct


### PR DESCRIPTION
This PR adds support for tracking reviews. Currently the labels annotation metadata is updated to track which superpixels have been reviewed, what their new value is, who did that review, as well as the date and time of the review. On retraining the labels are updated to the reviewed values (if there has been a change).

Relies on changes in #130 