### PR TITLE
Styling fixes

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -242,7 +242,7 @@ export default Vue.extend({
     left: 5px;
     width: 400px;
     border-radius: 5px;
-    box-shadow: 5px 5px 5px rgba(0,0,0,.5);
+    box-shadow: 3px 3px 5px 2px rgba(0,0,0,.5);
     padding: 5px;
     background-color: #fff;
 }

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -155,6 +155,7 @@ export default Vue.extend({
       <!-- Image Viewer -->
       <active-learning-slide-viewer
         ref="activeLearningSlideViewer"
+        class="slide-viewer"
         :available-images="availableImages"
         @synchronize="synchronizeCategories"
         @save-annotations="saveAnnotations"
@@ -222,7 +223,6 @@ export default Vue.extend({
 }
 
 .setup {
-    margin-left: 10px;
     height: 100%;
 }
 
@@ -263,4 +263,8 @@ export default Vue.extend({
     overflow: hidden;
 }
 
+.slide-viewer {
+    position: relative;
+    bottom: 3px;
+}
 </style>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -729,7 +729,7 @@ export default Vue.extend({
     flex-direction: column;
     background-color: #fff;
     border-radius: 5px;
-    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.5);
+    box-shadow: 3px 3px 5px 2px rgba(0,0,0,.5);
     padding: 5px;
     justify-content: space-between;
 }

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -100,7 +100,10 @@ export default Vue.extend({
       <select
         class="categories-selector"
       >
-        <option :value="null" :disabled="!superpixel.reviewCategory">
+        <option
+          :value="null"
+          :disabled="!superpixel.reviewCategory"
+        >
           {{ !superpixel.reviewCategory ? '' : 'Clear Review' }}
         </option>
         <option

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -832,6 +832,10 @@ export default Vue.extend({
   min-height: 150px;
 }
 
+.panel {
+  box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.25);
+}
+
 .panel-content-cards {
   display: flex;
   flex-wrap: wrap;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -812,6 +812,8 @@ export default Vue.extend({
   display: flex;
   max-height: 95vh;
   min-height: 10vh;
+  box-shadow: 3px 3px 5px 2px rgba(0, 0, 0, .5);
+  border-radius: 5px;
 }
 
 .settings-panel {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
@@ -92,4 +92,8 @@ export default Vue.extend({
 .h-generate-superpixel-btn {
     display: block;
 }
+
+.h-al-setup-superpixels {
+    margin-left: 10px;
+}
 </style>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
@@ -103,8 +103,8 @@ export default {
     min-width: 200px;
     display: flex;
     background-color: white;
-    border-radius: 1px;
-    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.5);
+    border-radius: 5px;
+    box-shadow: 3px 3px 5px 2px rgba(0,0,0,.5);
     width: 350px;
 }
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/MouseAndKeyboardControls.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/MouseAndKeyboardControls.vue
@@ -118,7 +118,7 @@ export default Vue.extend({
     display: flex;
     background-color: #fff;
     border-radius: 5px;
-    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.5);
+    box-shadow: 3px 3px 5px 2px rgba(0,0,0,.5);
     padding: 5px;
 }
 


### PR DESCRIPTION
- Round all dialog borders
- Add a small bit of shadow to make all dialogs visible on white backrounds
- Remove margin on left of image in initial labeling
- Remove top margin from slide image
- ~Add shadows to review view as well. This can be easily dropped if it makes things too cluttered/unclear.~ NOTE: Review card shadows dropped for now to avoid a cluttered feel. This can be addressed in the future if there is a need.

![image](https://github.com/user-attachments/assets/9e0c22ad-db1d-4b39-b653-27280aa81a73)
