### PR TITLE
Make sure prediction review selection is reset on retrain

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -643,6 +643,8 @@ const ActiveLearningView = View.extend({
                 train: true
             }
         }).done((job) => {
+            store.page = 0;
+            store.selectedIndex = 0;
             this.waitForJobCompletion(job._id, goToNextStep);
         });
     },


### PR DESCRIPTION
We remember the last selected prediction chip from the guided mode so that it is not reset when toggling between modes. When a retrain is requested though we need to make sure this is reset and the least certain chip is selected again.