### PR TITLE
Refactor filtering UI

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -83,7 +83,10 @@ export default Vue.extend({
             get() {
                 return this.superpixel.reviewValue || this.superpixel.selectedCategory;
             },
-            set(newCategory) {
+            set(newCategory, oldCategory) {
+                if (newCategory === oldCategory) {
+                    return;
+                }
                 updateMetadata(this.superpixel, newCategory, true);
                 store.backboneParent.saveAnnotationReviews(this.superpixel.imageId);
             }

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
             observedSuperpixel: null,
             totalSuperpixels: 0,
             reviewTable: true,
-            openMenu: null,
+            openMenu: null
         };
     },
     computed: {
@@ -522,7 +522,10 @@ export default Vue.extend({
                 {{ groupByOptions[groupBy] }}
                 <span class="caret" />
               </button>
-              <ul class="dropdown-menu" :style="{'top': 'auto'}">
+              <ul
+                class="dropdown-menu"
+                :style="{'top': 'auto'}"
+              >
                 <li
                   v-for="[key, value] in Object.entries(groupByOptions)"
                   :key="key"
@@ -560,7 +563,10 @@ export default Vue.extend({
                 {{ sortByOptions[sortBy] }}
                 <span class="caret" />
               </button>
-              <ul class="dropdown-menu" :style="{'top': 'auto'}">
+              <ul
+                class="dropdown-menu"
+                :style="{'top': 'auto'}"
+              >
                 <li
                   v-for="[key, value] in Object.entries(sortByOptions)"
                   :key="key"
@@ -650,17 +656,19 @@ export default Vue.extend({
                     </span>
                   </div>
                   <ul :class="['dropdown-menu', openMenu === 'slide' ? 'visible-menu' : 'hidden']">
-                    <li v-for="(imageName, index) in filterOptions.Slides">
+                    <li
+                      v-for="(imageName, index) in filterOptions.Slides"
+                      :key="`slide_${index}`"
+                    >
                       <label
                         :for="`slide_${index}`"
                         class="checkboxLabel"
-                        :key="`slide_${index}`"
                       >
                         <input
                           :id="`slide_${index}`"
                           v-model="filterBy"
                           type="checkbox"
-                          :value=imageName
+                          :value="imageName"
                         >
                         {{ imageName }}
                       </label>
@@ -669,8 +677,8 @@ export default Vue.extend({
                 </div>
                 <button
                   class="btn btn-danger btn-sm"
-                  @click="removeFilters(filterOptions.Slides)"
                   :disabled="!filterOptions.Slides.some(name => filterBy.includes(name))"
+                  @click="removeFilters(filterOptions.Slides)"
                 >
                   <i
                     class="icon-minus-squared"
@@ -694,17 +702,19 @@ export default Vue.extend({
                     </span>
                   </div>
                   <ul :class="['dropdown-menu', openMenu === 'labels' ? 'visible-menu' : 'hidden']">
-                    <li v-for="(cat, index) in filterOptions.Labels">
+                    <li
+                      v-for="(cat, index) in filterOptions.Labels"
+                      :key="`cat_${index}`"
+                    >
                       <label
                         :for="`cat_${index}`"
                         class="checkboxLabel"
-                        :key="`cat_${index}`"
                       >
                         <input
                           :id="`cat_${index}`"
                           v-model="filterBy"
                           type="checkbox"
-                          :value='`label_${cat}`'
+                          :value="`label_${cat}`"
                         >
                         {{ cat }}
                       </label>
@@ -713,8 +723,8 @@ export default Vue.extend({
                 </div>
                 <button
                   class="btn btn-danger btn-sm"
-                  @click="removeFilters(filterOptions.Labels.map(cat => `label_${cat}`))"
                   :disabled="!filterOptions.Labels.some(cat => filterBy.includes(`label_${cat}`))"
+                  @click="removeFilters(filterOptions.Labels.map(cat => `label_${cat}`))"
                 >
                   <i
                     class="icon-minus-squared"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -560,7 +560,7 @@ export default Vue.extend({
                 {{ sortByOptions[sortBy] }}
                 <span class="caret" />
               </button>
-              <ul class="dropdown-menu">
+              <ul class="dropdown-menu" :style="{'top': 'auto'}">
                 <li
                   v-for="[key, value] in Object.entries(sortByOptions)"
                   :key="key"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -771,77 +771,103 @@ export default Vue.extend({
               <option :value="1.00" />
             </datalist>
           </div>
-          <div>
-            <div
-              class="btn btn-primary btn-block"
-              @click="dataSelectMenu = !dataSelectMenu"
-            >
-              <span class="multiselect-dropdown-label">
-                Superpixel Data
-                <span class="caret" />
-              </span>
+          <div
+            :style="{'position': 'relative'}"
+            class="dropdown-dropup selector-with-button"
+          >
+            <div class="dropdown-button">
+              <div
+                class="btn btn-default btn-block"
+                @click="dataSelectMenu = !dataSelectMenu"
+              >
+                <span class="multiselect-dropdown-label">
+                  Superpixel Data
+                  <span class="caret" />
+                </span>
+              </div>
+              <ul
+                class="dropdown-menu"
+                :style="[dataSelectMenu ? {'display': 'block', 'padding': '10px 5px 5px 10px'} : {'display': 'none'}]"
+              >
+                <li>
+                  <label
+                    for="className"
+                    class="checkboxLabel"
+                  >
+                    <input
+                      id="className"
+                      v-model="cardDetails"
+                      type="checkbox"
+                      value="selectedCategory"
+                    >
+                    Class Name
+                  </label>
+                </li>
+                <li>
+                  <label
+                    for="confidence"
+                    class="checkboxLabel"
+                  >
+                    <input
+                      id="confidence"
+                      v-model="cardDetails"
+                      type="checkbox"
+                      value="confidence"
+                    >
+                    Confidence
+                  </label>
+                </li>
+                <li>
+                  <label
+                    for="certainty"
+                    class="checkboxLabel"
+                  >
+                    <input
+                      id="certainty"
+                      v-model="cardDetails"
+                      type="checkbox"
+                      value="certainty"
+                    >
+                    Certainty
+                  </label>
+                </li>
+                <li>
+                  <label
+                    for="prediction"
+                    class="checkboxLabel"
+                  >
+                    <input
+                      id="prediction"
+                      v-model="cardDetails"
+                      type="checkbox"
+                      value="prediction"
+                    >
+                    Prediction
+                  </label>
+                </li>
+              </ul>
             </div>
-            <ul
-              class="multiselect-dropdown-items"
-              :style="[dataSelectMenu ? {'display': 'flex'} : {'display': 'none'}]"
+            <button
+              class="btn btn-success btn-xs"
+              :style="{'margin-right': '3px'}"
+              @click="cardDetails=['selectedCategory', 'confidence', 'certainty', 'prediction']"
             >
-              <li>
-                <label
-                  for="className"
-                  class="checkboxLabel"
-                >
-                  <input
-                    id="className"
-                    v-model="cardDetails"
-                    type="checkbox"
-                    value="selectedCategory"
-                  >
-                  Class Name
-                </label>
-              </li>
-              <li>
-                <label
-                  for="confidence"
-                  class="checkboxLabel"
-                >
-                  <input
-                    id="confidence"
-                    v-model="cardDetails"
-                    type="checkbox"
-                    value="confidence"
-                  >
-                  Confidence
-                </label>
-              </li>
-              <li>
-                <label
-                  for="certainty"
-                  class="checkboxLabel"
-                >
-                  <input
-                    id="certainty"
-                    v-model="cardDetails"
-                    type="checkbox"
-                    value="certainty"
-                  >
-                  Certainty
-                </label>
-              </li>
-              <li>
-                <label
-                  for="prediction"
-                  class="checkboxLabel"
-                >
-                  <input
-                    id="prediction"
-                    v-model="cardDetails"
-                    type="checkbox"
-                    value="prediction"
-                  >
-                  Prediction
-                </label>
-              </li>
-            </ul>
+              <i
+                class="icon-ok-squared"
+                data-toggle="tooltip"
+                title="Show all"
+              />
+            </button>
+            <button
+              class="btn btn-danger btn-xs"
+              @click="cardDetails=[]"
+            >
+              <i
+                class="icon-minus-squared"
+                data-toggle="tooltip"
+                title="Hide all"
+              />
+            </button>
           </div>
         </div>
       </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -33,8 +33,7 @@ export default Vue.extend({
             observedSuperpixel: null,
             totalSuperpixels: 0,
             reviewTable: true,
-            slideFilterMenu: false,
-            labelCatFilterMenu: false
+            openMenu: null,
         };
     },
     computed: {
@@ -329,6 +328,9 @@ export default Vue.extend({
         },
         removeFilters(values) {
             this.filterBy = _.without(this.filterBy, ...values);
+        },
+        toggleOpenMenu(menu) {
+            this.openMenu = this.openMenu === menu ? null : menu;
         }
     }
 });
@@ -640,17 +642,14 @@ export default Vue.extend({
                 <div class="dropdown-button">
                   <div
                     class="btn btn-default btn-block"
-                    @click="slideFilterMenu = !slideFilterMenu"
+                    @click="toggleOpenMenu('slide')"
                   >
                     <span class="multiselect-dropdown-label">
                       Slide Image
                       <span class="caret" />
                     </span>
                   </div>
-                  <ul
-                    class="dropdown-menu"
-                    :style="[slideFilterMenu ? {'display': 'block', 'padding': '10px 5px 5px 10px'} : {'display': 'none'}]"
-                  >
+                  <ul :class="['dropdown-menu', openMenu === 'slide' ? 'visible-menu' : 'hidden']">
                     <li v-for="(imageName, index) in filterOptions.Slides">
                       <label
                         :for="`slide_${index}`"
@@ -687,17 +686,14 @@ export default Vue.extend({
                 <div class="dropdown-button">
                   <div
                     class="btn btn-default btn-block"
-                    @click="labelCatFilterMenu = !labelCatFilterMenu"
+                    @click="toggleOpenMenu('labels')"
                   >
                     <span class="multiselect-dropdown-label">
                       Labels
                       <span class="caret" />
                     </span>
                   </div>
-                  <ul
-                    class="dropdown-menu"
-                    :style="[labelCatFilterMenu ? {'display': 'block', 'padding': '10px 5px 5px 10px'} : {'display': 'none'}]"
-                  >
+                  <ul :class="['dropdown-menu', openMenu === 'labels' ? 'visible-menu' : 'hidden']">
                     <li v-for="(cat, index) in filterOptions.Labels">
                       <label
                         :for="`cat_${index}`"
@@ -778,17 +774,14 @@ export default Vue.extend({
             <div class="dropdown-button">
               <div
                 class="btn btn-default btn-block"
-                @click="dataSelectMenu = !dataSelectMenu"
+                @click="toggleOpenMenu('data')"
               >
                 <span class="multiselect-dropdown-label">
                   Superpixel Data
                   <span class="caret" />
                 </span>
               </div>
-              <ul
-                class="dropdown-menu"
-                :style="[dataSelectMenu ? {'display': 'block', 'padding': '10px 5px 5px 10px'} : {'display': 'none'}]"
-              >
+              <ul :class="['dropdown-menu', openMenu === 'data' ? 'visible-menu' : 'hidden']">
                 <li>
                   <label
                     for="className"
@@ -1274,5 +1267,10 @@ export default Vue.extend({
 
 .dropup-adjustment {
   top: auto;
+}
+
+.visible-menu {
+  display: block;
+  padding: 10px 5px 5px 10px;
 }
 </style>


### PR DESCRIPTION
First step of the filtering changes.

- Create two panels:
    - `Organize`: contains grouping and sorting menus
    - `Filtering`: contains all filtering menus
- Also adds a quick show all/hide all option to the detail information

![image](https://github.com/user-attachments/assets/c79d1edc-aa40-499c-ba35-cebf143d8bde)
