### PR TITLE
Comparison filtering

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -35,7 +35,7 @@ export default Vue.extend({
             reviewTable: true,
             openMenu: null,
             labelFlag: false,
-            predictionFlag: false
+            showFlags: false
         };
     },
     computed: {
@@ -164,12 +164,10 @@ export default Vue.extend({
             this.$nextTick(() => this.updateObserved());
         },
         firstComparison() {
-            this.labelFlag = !!this.firstComparison && !!this.booleanOperator;
-            this.predictionFlag = !!this.firstComparison && !!this.booleanOperator;
+            this.showFlags = !!this.firstComparison && !!this.booleanOperator;
         },
         booleanOperator() {
-            this.labelFlag = !!this.firstComparison && !!this.booleanOperator;
-            this.predictionFlag = !!this.firstComparison && !!this.booleanOperator;
+            this.showFlags = !!this.firstComparison && !!this.booleanOperator;
         }
     },
     mounted() {
@@ -1323,24 +1321,49 @@ export default Vue.extend({
           id="view"
           class="panel-body collapse in"
         >
-          <div class="preview-size-selector">
-            <label for="sizeSelector">Preview Size</label>
-            <input
-              id="sizeSelector"
-              v-model="previewSize"
-              type="range"
-              name="sizeSelector"
-              list="markers"
-              :step="0.25"
-              :min="0.25"
-              :max="1.0"
-            >
-            <datalist id="markers">
-              <option :value="0.25" />
-              <option :value="0.50" />
-              <option :value="0.75" />
-              <option :value="1.00" />
-            </datalist>
+          <div :style="{'display': 'flex'}">
+            <div class="preview-size-selector">
+              <label
+                for="sizeSelector"
+                :style="{'text-wrap': 'nowrap'}"
+              >Preview Size</label>
+              <input
+                id="sizeSelector"
+                v-model="previewSize"
+                type="range"
+                name="sizeSelector"
+                list="markers"
+                :step="0.25"
+                :min="0.25"
+                :max="1.0"
+              >
+              <datalist id="markers">
+                <option :value="0.25" />
+                <option :value="0.50" />
+                <option :value="0.75" />
+                <option :value="1.00" />
+              </datalist>
+            </div>
+            <div class="flag-options">
+              <label
+                for="flagVisibility"
+                :style="{'margin': '0px 5px'}"
+              >Flags</label>
+              <button
+                id="flagVisibility"
+                class="btn btn-xs"
+                @click="showFlags = !showFlags"
+              >
+                <i
+                  v-if="showFlags"
+                  class="icon-eye-off"
+                />
+                <i
+                  v-else
+                  class="icon-eye"
+                />
+              </button>
+            </div>
           </div>
           <div
             :style="{'position': 'relative'}"
@@ -1596,12 +1619,12 @@ export default Vue.extend({
                 :style="{'background-color': catColorByIndex(superpixel.reviewValue)}"
               />
               <i
-                v-if="superpixel.selectedCategory >= 0 && labelFlag"
+                v-if="superpixel.selectedCategory >= 0 && showFlags"
                 class="flag-bottom-left icon-tag"
                 :style="{'background-color': catColorByIndex(superpixel.selectedCategory)}"
               />
               <i
-                v-if="superpixel.prediction >= 0 && predictionFlag"
+                v-if="superpixel.prediction >= 0 && showFlags"
                 class="flag-bottom-right icon-lightbulb"
                 :style="{'background-color': predColorByIndex(superpixel)}"
               />
@@ -1712,6 +1735,9 @@ export default Vue.extend({
 
 .preview-size-selector {
   margin-bottom: 5px;
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
 }
 
 .chips-container {
@@ -1888,5 +1914,11 @@ export default Vue.extend({
 
 .disabled-label input {
   pointer-events: none;
+}
+
+.flag-options {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-evenly;
 }
 </style>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -1590,25 +1590,20 @@ export default Vue.extend({
                 data-target="#context"
                 @click.native="selectedSuperpixel = superpixel"
               />
-              <div
+              <i
                 v-if="!!superpixel.reviewValue"
-                class="flag chip-overlay"
-                :style="{'left': '-2px'}"
-              >
-                <i
-                  class="icon-user"
-                  :style="{'color': 'white'}"
-                />
-              </div>
+                class="flag-top-left icon-user"
+                :style="{'background-color': catColorByIndex(superpixel.reviewValue)}"
+              />
               <i
                 v-if="superpixel.selectedCategory >= 0 && labelFlag"
                 class="flag-bottom-left icon-tag"
-                :style="{'color': catColorByIndex(superpixel.selectedCategory)}"
+                :style="{'background-color': catColorByIndex(superpixel.selectedCategory)}"
               />
               <i
                 v-if="superpixel.prediction >= 0 && predictionFlag"
                 class="flag-bottom-right icon-lightbulb"
-                :style="{'color': predColorByIndex(superpixel)}"
+                :style="{'background-color': predColorByIndex(superpixel)}"
               />
               <input
                 v-show="selectingSuperpixels"
@@ -1816,23 +1811,13 @@ export default Vue.extend({
   top: -4px;
 }
 
-.flag {
-  background-color: #337ab7;
-  padding: 3px 3px 20px;
-  clip-path: polygon(0 0, 100% 0, 100% 50%, 50% 65%, 0 50%);
-  border-radius: 2px;
-  float: left;
-  width: 25px;
-  top: -2px;
-}
-
 .flag-top-left {
   position: absolute;
   top: -2px;
   z-index: 100;
   font-size: 16px;
   border-radius: 18px;
-  background-color: white;
+  color: white;
   left: -2px;
 }
 
@@ -1842,7 +1827,7 @@ export default Vue.extend({
   z-index: 100;
   font-size: 16px;
   border-radius: 18px;
-  background-color: white;
+  color: white;
   left: -2px;
 }
 
@@ -1852,7 +1837,7 @@ export default Vue.extend({
   z-index: 100;
   font-size: 16px;
   border-radius: 18px;
-  background-color: white;
+  color: white;
   right: -2px;
 }
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -132,7 +132,19 @@ export default Vue.extend({
         cardDetails: {
             get() { return store.cardDetails; },
             set(value) { store.cardDetails = value; }
-        }
+        },
+        firstComparison: {
+            get() { return store.firstComparison; },
+            set(value) { store.firstComparison = value; }
+        },
+        secondComparison: {
+            get() { return store.secondComparison; },
+            set(value) { store.secondComparison = value; }
+        },
+        booleanOperator: {
+            get() { return store.booleanOperator; },
+            set(value) { store.booleanOperator = value; }
+        },
     },
     watch: {
         selectedSuperpixel() {
@@ -948,6 +960,240 @@ export default Vue.extend({
                     />
                   </button>
                 </div>
+              </div>
+              <label for="comp">Filter By Comparison</label>
+              <div id="comp" class="flex">
+                <div
+                  class="dropdown-dropup selector-with-button"
+                  :style="{'width': '35%'}"
+                >
+                  <button
+                    class="btn btn-block btn-default dropdown-toggle dropdown-button"
+                    type="button"
+                    data-toggle="dropdown"
+                  >
+                    {{ firstComparison }}
+                    <span class="caret" />
+                  </button>
+                  <ul class="dropdown-menu">
+                    <li>
+                      <div class="radio">
+                        <label for="no_selection_1">
+                          <input
+                            id="no_selection_1"
+                            v-model="firstComparison"
+                            type="radio"
+                            :value="null"
+                            class="hidden-radio"
+                          >
+                          (None)
+                        </label>
+                      </div>
+                    </li>
+                    <li>
+                      <div class="radio">
+                        <label for="prediction_1">
+                          <input
+                            id="prediction_1"
+                            v-model="firstComparison"
+                            type="radio"
+                            value="prediction"
+                            class="hidden-radio"
+                          >
+                          Predictions
+                        </label>
+                      </div>
+                    </li>
+                    <li
+                      v-for="[key, value] in Object.entries(filterOptions.Labelers)"
+                      :key="`comp_labeler_${key}`"
+                    >
+                      <div class="radio">
+                        <label :for="`comp_labeler_${key}_1`">
+                          <input
+                            :id="`comp_labeler_${key}_1`"
+                            v-model="firstComparison"
+                            type="radio"
+                            :value="`label_${key}`"
+                            class="hidden-radio"
+                          >
+                          {{ value[0].labeler.firstName }} {{ value[0].labeler.lastName }} Labels
+                        </label>
+                      </div>
+                    </li>
+                    <li
+                      v-for="[key, value] in Object.entries(filterOptions.Reviewers)"
+                      :key="`comp_reviewer_${key}`"
+                    >
+                      <div class="radio">
+                        <label :for="`comp_reviewer_${key}_1`">
+                          <input
+                            :id="`comp_reviewer_${key}_1`"
+                            v-model="firstComparison"
+                            type="radio"
+                            :value="`review_${key}`"
+                            class="hidden-radio"
+                          >
+                          {{ value[0].reviewer.firstName }} {{ value[0].reviewer.lastName }} Reviews
+                        </label>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <div
+                  class="dropdown-dropup selector-with-button"
+                  :style="{'width': '30%'}"
+                >
+                  <button
+                    class="btn btn-block btn-default dropdown-toggle dropdown-button"
+                    type="button"
+                    data-toggle="dropdown"
+                  >
+                    {{ booleanOperator }}
+                    <span class="caret" />
+                  </button>
+                  <ul class="dropdown-menu">
+                    <li>
+                      <div class="radio">
+                        <label
+                          for="no_selection_2"
+                          class="options"
+                        >
+                          <input
+                            id="no_selection_2"
+                            v-model="booleanOperator"
+                            type="radio"
+                            :value="null"
+                            class="hidden-radio"
+                          >
+                          (None)
+                        </label>
+                      </div>
+                    </li>
+                    <li>
+                      <div class="radio">
+                        <label
+                          for="matches"
+                          class="options"
+                        >
+                          <input
+                            id="matches"
+                            v-model="booleanOperator"
+                            type="radio"
+                            value="matches"
+                            class="hidden-radio"
+                          >
+                          matches
+                        </label>
+                      </div>
+                    </li>
+                    <li>
+                      <div class="radio">
+                        <label
+                          for="differsFrom"
+                          class="options"
+                        >
+                          <input
+                            id="differsFrom"
+                            v-model="booleanOperator"
+                            type="radio"
+                            value="differs from"
+                            class="hidden-radio"
+                          >
+                          differs from
+                        </label>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <div
+                  class="dropdown-dropup selector-with-button"
+                  :style="{'width': '35%'}"
+                >
+                  <button
+                    class="btn btn-block btn-default dropdown-toggle dropdown-button"
+                    type="button"
+                    data-toggle="dropdown"
+                  >
+                    {{ secondComparison }}
+                    <span class="caret" />
+                  </button>
+                  <ul class="dropdown-menu">
+                    <li>
+                      <div class="radio" :disabled="firstComparison === 'prediction'">
+                        <label for="all">
+                          <input
+                            id="all"
+                            v-model="secondComparison"
+                            type="radio"
+                            :value="null"
+                            class="hidden-radio"
+                          >
+                          {{ !firstComparison && !booleanOperator ? 'All' : '(None)'}}
+                        </label>
+                      </div>
+                    </li>
+                    <li>
+                      <div class="radio" :disabled="firstComparison === 'prediction'">
+                        <label for="prediction_2">
+                          <input
+                            id="prediction_2"
+                            v-model="secondComparison"
+                            type="radio"
+                            value="prediction"
+                            class="hidden-radio"
+                          >
+                          Predictions
+                        </label>
+                      </div>
+                    </li>
+                    <li
+                      v-for="[key, value] in Object.entries(filterOptions.Labelers)"
+                      :key="`comp_labeler_${key}_2`"
+                    >
+                      <div class="radio">
+                        <label :for="`comp_labeler_${key}_2`">
+                          <input
+                            :id="`comp_labeler_${key}_2`"
+                            v-model="secondComparison"
+                            type="radio"
+                            :value="`label_${key}`"
+                            class="hidden-radio"
+                          >
+                          {{ value[0].labeler.firstName }} {{ value[0].labeler.lastName }} Labels
+                        </label>
+                      </div>
+                    </li>
+                    <li
+                      v-for="[key, value] in Object.entries(filterOptions.Reviewers)"
+                      :key="`comp_reviewer_${key}_2`"
+                    >
+                      <div class="radio">
+                        <label :for="`comp_reviewer_${key}_2`">
+                          <input
+                            :id="`comp_reviewer_${key}_2`"
+                            v-model="secondComparison"
+                            type="radio"
+                            :value="`review_${key}`"
+                            class="hidden-radio"
+                          >
+                          {{ value[0].reviewer.firstName }} {{ value[0].reviewer.lastName }} Reviews
+                        </label>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <button
+                  class="btn btn-danger btn-xs"
+                  :disabled="!this.firstComparison && !this.booleanOperator && !this.secondComparison"
+                  @click="() => {this.firstComparison = this.booleanOperator = this.secondComparison = null}"
+                >
+                  <i
+                    class="icon-minus-squared"
+                    data-toggle="tooltip"
+                    title="Clear comparison filters"
+                  />
+                </button>
               </div>
             </div>
           </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -1291,6 +1291,7 @@ export default Vue.extend({
                 <button
                   class="btn btn-danger btn-xs"
                   :disabled="!firstComparison && !booleanOperator && !secondComparison"
+                  :style="{'margin-bottom': '3px'}"
                   @click="() => {firstComparison = booleanOperator = secondComparison = null}"
                 >
                   <i

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -1046,7 +1046,9 @@ export default Vue.extend({
                     type="button"
                     data-toggle="dropdown"
                   >
-                    {{ selectedComparisonText(firstComparison) || '(None)' }}
+                    <span class="overflow-text">
+                      {{ selectedComparisonText(firstComparison) || '(None)' }}
+                    </span>
                     <span class="caret" />
                   </button>
                   <ul class="dropdown-menu">
@@ -1198,7 +1200,9 @@ export default Vue.extend({
                     type="button"
                     data-toggle="dropdown"
                   >
-                    {{ selectedComparisonText(secondComparison) || (!!firstComparison && !!booleanOperator ? 'Any' : '(None)') }}
+                    <span class="overflow-text">
+                      {{ selectedComparisonText(secondComparison) || (!!firstComparison && !!booleanOperator ? 'Any' : '(None)') }}
+                    </span>
                     <span class="caret" />
                   </button>
                   <ul class="dropdown-menu">
@@ -1714,7 +1718,7 @@ export default Vue.extend({
   margin-right: 3px;
 }
 
-.filter-text {
+.overflow-text {
   text-overflow: ellipsis;
   overflow: hidden;
 }

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -1018,7 +1018,10 @@ export default Vue.extend({
                     </li>
                     <li>
                       <div class="radio">
-                        <label for="prediction_1">
+                        <label
+                          for="prediction_1"
+                          :class="['options', secondComparison === 'prediction' && 'disabled-label']"
+                        >
                           <input
                             id="prediction_1"
                             v-model="firstComparison"
@@ -1035,7 +1038,10 @@ export default Vue.extend({
                       :key="`comp_labeler_${key}`"
                     >
                       <div class="radio">
-                        <label :for="`comp_labeler_${key}_1`">
+                        <label
+                          :for="`comp_labeler_${key}_1`"
+                          :class="['options', (!!secondComparison && secondComparison.startsWith('label')) && 'disabled-label']"
+                        >
                           <input
                             :id="`comp_labeler_${key}_1`"
                             v-model="firstComparison"
@@ -1052,7 +1058,10 @@ export default Vue.extend({
                       :key="`comp_reviewer_${key}`"
                     >
                       <div class="radio">
-                        <label :for="`comp_reviewer_${key}_1`">
+                        <label
+                          :for="`comp_reviewer_${key}_1`"
+                          :class="['options', (!!secondComparison && secondComparison.startsWith('review')) && 'disabled-label']"
+                        >
                           <input
                             :id="`comp_reviewer_${key}_1`"
                             v-model="firstComparison"
@@ -1147,7 +1156,10 @@ export default Vue.extend({
                   <ul class="dropdown-menu">
                     <li>
                       <div class="radio" :disabled="firstComparison === 'prediction'">
-                        <label for="all">
+                        <label
+                          for="all"
+                          :class="['options', firstComparison === 'prediction' && 'disabled-label']"
+                        >
                           <input
                             id="all"
                             v-model="secondComparison"
@@ -1161,7 +1173,10 @@ export default Vue.extend({
                     </li>
                     <li>
                       <div class="radio" :disabled="firstComparison === 'prediction'">
-                        <label for="prediction_2">
+                        <label
+                          for="prediction_2"
+                          :class="['options', firstComparison === 'prediction' && 'disabled-label']"
+                        >
                           <input
                             id="prediction_2"
                             v-model="secondComparison"
@@ -1178,7 +1193,10 @@ export default Vue.extend({
                       :key="`comp_labeler_${key}_2`"
                     >
                       <div class="radio">
-                        <label :for="`comp_labeler_${key}_2`">
+                        <label
+                          :for="`comp_labeler_${key}_2`"
+                          :class="['options', (!!firstComparison && firstComparison.startsWith('label')) && 'disabled-label']"
+                        >
                           <input
                             :id="`comp_labeler_${key}_2`"
                             v-model="secondComparison"
@@ -1195,7 +1213,10 @@ export default Vue.extend({
                       :key="`comp_reviewer_${key}_2`"
                     >
                       <div class="radio">
-                        <label :for="`comp_reviewer_${key}_2`">
+                        <label
+                          :for="`comp_reviewer_${key}_2`"
+                          :class="['options', (!!firstComparison && firstComparison.startsWith('review')) && 'disabled-label']"
+                        >
                           <input
                             :id="`comp_reviewer_${key}_2`"
                             v-model="secondComparison"
@@ -1774,5 +1795,14 @@ export default Vue.extend({
 
 .flex {
   display: flex;
+}
+
+.disabled-label {
+  color: #aaa;
+  cursor: not-allowed;
+}
+
+.disabled-label input {
+  pointer-events: none;
 }
 </style>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -1197,24 +1197,24 @@ export default Vue.extend({
                     type="button"
                     data-toggle="dropdown"
                   >
-                    {{ selectedComparisonText(secondComparison) || (!!firstComparison && !!booleanOperator ? 'All' : '(None)')}}
+                    {{ selectedComparisonText(secondComparison) || (!!firstComparison && !!booleanOperator ? 'Any' : '(None)')}}
                     <span class="caret" />
                   </button>
                   <ul class="dropdown-menu">
                     <li>
                       <div class="radio" :disabled="firstComparison === 'prediction'">
                         <label
-                          for="all"
+                          for="any"
                           :class="['options', firstComparison === 'prediction' && 'disabled-label']"
                         >
                           <input
-                            id="all"
+                            id="any"
                             v-model="secondComparison"
                             type="radio"
                             :value="null"
                             class="hidden-radio"
                           >
-                            All
+                            Any
                         </label>
                       </div>
                     </li>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -638,6 +638,7 @@ export default Vue.extend({
             <label for="groupby">Group By</label>
             <div
               id="groupby"
+              :style="{'position': 'relative'}"
               class="dropdown-dropup selector-with-button"
             >
               <button
@@ -648,10 +649,7 @@ export default Vue.extend({
                 {{ groupByOptions[groupBy] }}
                 <span class="caret" />
               </button>
-              <ul
-                class="dropdown-menu"
-                :style="{'top': 'auto'}"
-              >
+              <ul class="dropdown-menu">
                 <li
                   v-for="[key, value] in Object.entries(groupByOptions)"
                   :key="key"
@@ -690,6 +688,7 @@ export default Vue.extend({
             <label for="sortby">Sort By</label>
             <div
               id="sortby"
+              :style="{'position': 'relative'}"
               class="dropdown-dropup selector-with-button"
             >
               <button
@@ -700,10 +699,7 @@ export default Vue.extend({
                 {{ sortByOptions[sortBy] }}
                 <span class="caret" />
               </button>
-              <ul
-                class="dropdown-menu"
-                :style="{'top': 'auto'}"
-              >
+              <ul class="dropdown-menu">
                 <li
                   v-for="[key, value] in Object.entries(sortByOptions)"
                   :key="key"
@@ -934,7 +930,7 @@ export default Vue.extend({
                   <button
                     class="btn btn-danger btn-xs"
                     :disabled="!filterBy.includes('no review') && !filterOptions.Reviews.some(cat => filterBy.includes(`review_${cat}`))"
-                    @click="removeFilters(filterOptions.Reviews.map(cat => `review_${cat}`))"
+                    @click="removeFilters(['no review', ...filterOptions.Reviews.map(cat => `review_${cat}`)])"
                   >
                     <i
                       class="icon-minus-squared"
@@ -1042,7 +1038,7 @@ export default Vue.extend({
               <div id="comp" class="flex">
                 <div
                   class="dropdown-dropup selector-with-button"
-                  :style="{'width': '35%'}"
+                  :style="{'width': '35%', 'position': 'relative'}"
                 >
                   <button
                     class="btn btn-block btn-default dropdown-toggle dropdown-button"
@@ -1128,7 +1124,7 @@ export default Vue.extend({
                 </div>
                 <div
                   class="dropdown-dropup selector-with-button"
-                  :style="{'width': '30%'}"
+                  :style="{'width': '30%', 'position': 'relative'}"
                 >
                   <button
                     class="btn btn-block btn-default dropdown-toggle dropdown-button"
@@ -1194,7 +1190,7 @@ export default Vue.extend({
                 </div>
                 <div
                   class="dropdown-dropup selector-with-button"
-                  :style="{'width': '35%'}"
+                  :style="{'width': '35%', 'position': 'relative'}"
                 >
                   <button
                     class="btn btn-block btn-default dropdown-toggle dropdown-button"
@@ -1489,7 +1485,10 @@ export default Vue.extend({
             >
               Approve
             </button>
-            <div class="dropdown-dropup btn-group-two">
+            <div
+              class="dropdown-dropup btn-group-two"
+              :style="{'position': 'relative'}"
+            >
               <button
                 class="btn btn-primary dropdown-toggle btn-block"
                 :style="{'text-wrap': 'pretty'}"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -1621,16 +1621,22 @@ export default Vue.extend({
                 v-if="!!superpixel.reviewValue"
                 class="flag-top-left icon-user"
                 :style="{'background-color': catColorByIndex(superpixel.reviewValue)}"
+                data-toggle="tooltip"
+                :title="`Review: ${superpixel.labelCategories[superpixel.reviewValue].label}`"
               />
               <i
                 v-if="superpixel.selectedCategory >= 0 && showFlags"
                 class="flag-bottom-left icon-tag"
                 :style="{'background-color': catColorByIndex(superpixel.selectedCategory)}"
+                data-toggle="tooltip"
+                :title="`Label: ${superpixel.labelCategories[superpixel.selectedCategory].label}`"
               />
               <i
                 v-if="superpixel.prediction >= 0 && showFlags"
                 class="flag-bottom-right icon-lightbulb"
                 :style="{'background-color': predColorByIndex(superpixel)}"
+                data-toggle="tooltip"
+                :title="`Prediction: ${superpixel.predictionCategories[superpixel.prediction].label}`"
               />
               <input
                 v-show="selectingSuperpixels"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -380,6 +380,32 @@ export default Vue.extend({
         },
         toggleOpenMenu(menu) {
             this.openMenu = this.openMenu === menu ? null : menu;
+        },
+        selectedComparisonText(selection) {
+            if (!selection || selection === 'prediction') {
+                return selection;
+            } else {
+                let [key, userID] = selection.split('_');
+                let user;
+                if (store.currentUser._id === userID) {
+                    user = store.currentUser;
+                } else {
+                    const superpixel = _.find(this.superpixelsForReview, (superpixel) => {
+                        if (!!superpixel.meta) {
+                            return (
+                              (!!superpixel.meta.reviewer && superpixel.meta.reviewer._id === userID) ||
+                              (!!superpixel.meta.labeler && superpixel.meta.labeler._id === userID)
+                            )
+                        }
+                        return false;
+                    });
+                    user = superpixel.meta.labeler;
+                    if (!!superpixel.meta.reviewer && superpixel.meta.reviewer._id === userID) {
+                        user = superpixel.meta.reviewer;
+                    }
+                }
+                return `${user.firstName} ${user.lastName} ${key}s`
+            }
         }
     }
 });
@@ -972,7 +998,7 @@ export default Vue.extend({
                     type="button"
                     data-toggle="dropdown"
                   >
-                    {{ firstComparison }}
+                    {{ selectedComparisonText(firstComparison) || '(None)' }}
                     <span class="caret" />
                   </button>
                   <ul class="dropdown-menu">
@@ -1049,7 +1075,7 @@ export default Vue.extend({
                     type="button"
                     data-toggle="dropdown"
                   >
-                    {{ booleanOperator }}
+                    {{ booleanOperator || '(None)' }}
                     <span class="caret" />
                   </button>
                   <ul class="dropdown-menu">
@@ -1115,7 +1141,7 @@ export default Vue.extend({
                     type="button"
                     data-toggle="dropdown"
                   >
-                    {{ secondComparison }}
+                    {{ selectedComparisonText(secondComparison) || (!!firstComparison && !!booleanOperator ? 'All' : '(None)')}}
                     <span class="caret" />
                   </button>
                   <ul class="dropdown-menu">
@@ -1129,7 +1155,7 @@ export default Vue.extend({
                             :value="null"
                             class="hidden-radio"
                           >
-                          {{ !firstComparison && !booleanOperator ? 'All' : '(None)'}}
+                            All
                         </label>
                       </div>
                     </li>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -747,203 +747,207 @@ export default Vue.extend({
                   />
                 </button>
               </div>
-              <div
-                :style="{'position': 'relative'}"
-                class="dropdown-dropup selector-with-button"
-              >
-                <div class="dropdown-button">
-                  <div
-                    class="btn btn-default btn-block"
-                    @click="toggleOpenMenu('labels')"
-                  >
-                    <span class="multiselect-dropdown-label">
-                      Labels
-                      <span class="caret" />
-                    </span>
-                  </div>
-                  <ul :class="['dropdown-menu', openMenu === 'labels' ? 'visible-menu' : 'hidden']">
-                    <li
-                      v-for="(cat, index) in filterOptions.Labels"
-                      :key="`cat_${index}`"
-                    >
-                      <label
-                        :for="`cat_${index}`"
-                        class="checkboxLabel"
-                      >
-                        <input
-                          :id="`cat_${index}`"
-                          v-model="filterBy"
-                          type="checkbox"
-                          :value="`label_${cat}`"
-                        >
-                        {{ cat }}
-                      </label>
-                    </li>
-                  </ul>
-                </div>
-                <button
-                  class="btn btn-danger btn-sm"
-                  :disabled="!filterOptions.Labels.some(cat => filterBy.includes(`label_${cat}`))"
-                  @click="removeFilters(filterOptions.Labels.map(cat => `label_${cat}`))"
+              <div class="flex">
+                <div
+                  :style="{'position': 'relative', 'margin-right': '3px', 'width': '50%'}"
+                  class="dropdown-dropup selector-with-button"
                 >
-                  <i
-                    class="icon-minus-squared"
-                    data-toggle="tooltip"
-                    title="Clear all filters"
-                  />
-                </button>
+                  <div class="dropdown-button">
+                    <div
+                      class="btn btn-default btn-block"
+                      @click="toggleOpenMenu('labels')"
+                    >
+                      <span class="multiselect-dropdown-label">
+                        Labels
+                        <span class="caret" />
+                      </span>
+                    </div>
+                    <ul :class="['dropdown-menu', openMenu === 'labels' ? 'visible-menu' : 'hidden']">
+                      <li
+                        v-for="(cat, index) in filterOptions.Labels"
+                        :key="`cat_${index}`"
+                      >
+                        <label
+                          :for="`cat_${index}`"
+                          class="checkboxLabel"
+                        >
+                          <input
+                            :id="`cat_${index}`"
+                            v-model="filterBy"
+                            type="checkbox"
+                            :value="`label_${cat}`"
+                          >
+                          {{ cat }}
+                        </label>
+                      </li>
+                    </ul>
+                  </div>
+                  <button
+                    class="btn btn-danger btn-xs"
+                    :disabled="!filterOptions.Labels.some(cat => filterBy.includes(`label_${cat}`))"
+                    @click="removeFilters(filterOptions.Labels.map(cat => `label_${cat}`))"
+                  >
+                    <i
+                      class="icon-minus-squared"
+                      data-toggle="tooltip"
+                      title="Clear all filters"
+                    />
+                  </button>
+                </div>
+                <div
+                  :style="{'position': 'relative', 'width': '50%'}"
+                  class="dropdown-dropup selector-with-button"
+                >
+                  <div class="dropdown-button">
+                    <div
+                      class="btn btn-default btn-block"
+                      @click="toggleOpenMenu('reviews')"
+                    >
+                      <span class="multiselect-dropdown-label">
+                        Reviews
+                        <span class="caret" />
+                      </span>
+                    </div>
+                    <ul :class="['dropdown-menu', openMenu === 'reviews' ? 'visible-menu' : 'hidden']">
+                      <li>
+                        <label
+                          for="no review"
+                          class="checkboxLabel"
+                        >
+                          <input
+                            id="no review"
+                            v-model="filterBy"
+                            type="checkbox"
+                            value="no review"
+                          >
+                          not reviewed
+                        </label>
+                      </li>
+                      <li
+                        v-for="(cat, index) in filterOptions.Reviews"
+                        :key="`review_${index}`"
+                      >
+                        <label
+                          :for="`review_${index}`"
+                          class="checkboxLabel"
+                        >
+                          <input
+                            :id="`review_${index}`"
+                            v-model="filterBy"
+                            type="checkbox"
+                            :value="`review_${cat}`"
+                          >
+                          {{ cat }}
+                        </label>
+                      </li>
+                    </ul>
+                  </div>
+                  <button
+                    class="btn btn-danger btn-xs"
+                    :disabled="!filterBy.includes('no review') && !filterOptions.Reviews.some(cat => filterBy.includes(`review_${cat}`))"
+                    @click="removeFilters(filterOptions.Reviews.map(cat => `review_${cat}`))"
+                  >
+                    <i
+                      class="icon-minus-squared"
+                      data-toggle="tooltip"
+                      title="Clear all filters"
+                    />
+                  </button>
+                </div>
               </div>
-              <div
-                :style="{'position': 'relative'}"
-                class="dropdown-dropup selector-with-button"
-              >
-                <div class="dropdown-button">
-                  <div
-                    class="btn btn-default btn-block"
-                    @click="toggleOpenMenu('reviews')"
-                  >
-                    <span class="multiselect-dropdown-label">
-                      Reviews
-                      <span class="caret" />
-                    </span>
-                  </div>
-                  <ul :class="['dropdown-menu', openMenu === 'reviews' ? 'visible-menu' : 'hidden']">
-                    <li>
-                      <label
-                        for="no review"
-                        class="checkboxLabel"
-                      >
-                        <input
-                          id="no review"
-                          v-model="filterBy"
-                          type="checkbox"
-                          value="no review"
-                        >
-                        not reviewed
-                      </label>
-                    </li>
-                    <li
-                      v-for="(cat, index) in filterOptions.Reviews"
-                      :key="`review_${index}`"
-                    >
-                      <label
-                        :for="`review_${index}`"
-                        class="checkboxLabel"
-                      >
-                        <input
-                          :id="`review_${index}`"
-                          v-model="filterBy"
-                          type="checkbox"
-                          :value="`review_${cat}`"
-                        >
-                        {{ cat }}
-                      </label>
-                    </li>
-                  </ul>
-                </div>
-                <button
-                  class="btn btn-danger btn-sm"
-                  :disabled="!filterBy.includes('no review') && !filterOptions.Reviews.some(cat => filterBy.includes(`review_${cat}`))"
-                  @click="removeFilters(['no review', ...filterOptions.Reviews.map(cat => `review_${cat}`)])"
+              <div class="flex">
+                <div
+                  :style="{'position': 'relative', 'margin-right': '3px', 'width': '50%'}"
+                  class="dropdown-dropup selector-with-button"
                 >
-                  <i
-                    class="icon-minus-squared"
-                    data-toggle="tooltip"
-                    title="Clear all filters"
-                  />
-                </button>
-              </div>
-              <div
-                :style="{'position': 'relative'}"
-                class="dropdown-dropup selector-with-button"
-              >
-                <div class="dropdown-button">
-                  <div
-                    class="btn btn-default btn-block"
-                    @click="toggleOpenMenu('labeler')"
-                  >
-                    <span class="multiselect-dropdown-label">
-                      Labeled By
-                      <span class="caret" />
-                    </span>
-                  </div>
-                  <ul :class="['dropdown-menu', openMenu === 'labeler' ? 'visible-menu' : 'hidden']">
-                    <li
-                      v-for="[key, value] in Object.entries(filterOptions.Labelers)"
-                      :key="`labeler_${key}`"
+                  <div class="dropdown-button">
+                    <div
+                      class="btn btn-default btn-block"
+                      @click="toggleOpenMenu('labeler')"
                     >
-                      <label
-                        :for="`labeler_${key}`"
-                        class="checkboxLabel"
+                      <span class="multiselect-dropdown-label">
+                        Labeled By
+                        <span class="caret" />
+                      </span>
+                    </div>
+                    <ul :class="['dropdown-menu', openMenu === 'labeler' ? 'visible-menu' : 'hidden']">
+                      <li
+                        v-for="[key, value] in Object.entries(filterOptions.Labelers)"
+                        :key="`labeler_${key}`"
                       >
-                        <input
-                          :id="`labeler_${key}`"
-                          v-model="filterBy"
-                          type="checkbox"
-                          :value="`labeler_${key}`"
+                        <label
+                          :for="`labeler_${key}`"
+                          class="checkboxLabel"
                         >
-                        {{ value[0].labeler.firstName }} {{ value[0].labeler.lastName }}
-                      </label>
-                    </li>
-                  </ul>
-                </div>
-                <button
-                  class="btn btn-danger btn-sm"
-                  :disabled="!Object.keys(filterOptions.Labelers).some(cat => filterBy.includes(`labeler_${cat}`))"
-                  @click="removeFilters(Object.keys(filterOptions.Labelers).map((k) => `labeler_${k}`))"
-                >
-                  <i
-                    class="icon-minus-squared"
-                    data-toggle="tooltip"
-                    title="Clear all filters"
-                  />
-                </button>
-              </div>
-              <div
-                :style="{'position': 'relative'}"
-                class="dropdown-dropup selector-with-button"
-              >
-                <div class="dropdown-button">
-                  <div
-                    class="btn btn-default btn-block"
-                    @click="toggleOpenMenu('reviewer')"
-                  >
-                    <span class="multiselect-dropdown-label">
-                      Reviewed By
-                      <span class="caret" />
-                    </span>
+                          <input
+                            :id="`labeler_${key}`"
+                            v-model="filterBy"
+                            type="checkbox"
+                            :value="`labeler_${key}`"
+                          >
+                          {{ value[0].labeler.firstName }} {{ value[0].labeler.lastName }}
+                        </label>
+                      </li>
+                    </ul>
                   </div>
-                  <ul :class="['dropdown-menu', openMenu === 'reviewer' ? 'visible-menu' : 'hidden']">
-                    <li
-                      v-for="[key, value] in Object.entries(filterOptions.Reviewers)"
-                      :key="`reviewer_${key}`"
-                    >
-                      <label
-                        :for="`reviewer_${key}`"
-                        class="checkboxLabel"
-                      >
-                        <input
-                          :id="`reviewer_${key}`"
-                          v-model="filterBy"
-                          type="checkbox"
-                          :value="`reviewer_${key}`"
-                        >
-                        {{ value[0].reviewer.firstName }} {{ value[0].reviewer.lastName }}
-                      </label>
-                    </li>
-                  </ul>
+                  <button
+                    class="btn btn-danger btn-xs"
+                    :disabled="!Object.keys(filterOptions.Labelers).some(cat => filterBy.includes(`labeler_${cat}`))"
+                    @click="removeFilters(Object.keys(filterOptions.Labelers).map((k) => `labeler_${k}`))"
+                  >
+                    <i
+                      class="icon-minus-squared"
+                      data-toggle="tooltip"
+                      title="Clear all filters"
+                    />
+                  </button>
                 </div>
-                <button
-                  class="btn btn-danger btn-sm"
-                  :disabled="!Object.keys(filterOptions.Reviewers).some(k => filterBy.includes(`reviewer_${k}`))"
-                  @click="removeFilters(Object.keys(filterOptions.Reviewers).map((k) => `reviewer_${k}`))"
+                <div
+                  :style="{'position': 'relative', 'width': '50%'}"
+                  class="dropdown-dropup selector-with-button"
                 >
-                  <i
-                    class="icon-minus-squared"
-                    data-toggle="tooltip"
-                    title="Clear all filters"
-                  />
-                </button>
+                  <div class="dropdown-button">
+                    <div
+                      class="btn btn-default btn-block"
+                      @click="toggleOpenMenu('reviewer')"
+                    >
+                      <span class="multiselect-dropdown-label">
+                        Reviewed By
+                        <span class="caret" />
+                      </span>
+                    </div>
+                    <ul :class="['dropdown-menu', openMenu === 'reviewer' ? 'visible-menu' : 'hidden']">
+                      <li
+                        v-for="[key, value] in Object.entries(filterOptions.Reviewers)"
+                        :key="`reviewer_${key}`"
+                      >
+                        <label
+                          :for="`reviewer_${key}`"
+                          class="checkboxLabel"
+                        >
+                          <input
+                            :id="`reviewer_${key}`"
+                            v-model="filterBy"
+                            type="checkbox"
+                            :value="`reviewer_${key}`"
+                          >
+                          {{ value[0].reviewer.firstName }} {{ value[0].reviewer.lastName }}
+                        </label>
+                      </li>
+                    </ul>
+                  </div>
+                  <button
+                    class="btn btn-danger btn-xs"
+                    :disabled="!Object.keys(filterOptions.Reviewers).some(k => filterBy.includes(`reviewer_${k}`))"
+                    @click="removeFilters(Object.keys(filterOptions.Reviewers).map((k) => `reviewer_${k}`))"
+                  >
+                    <i
+                      class="icon-minus-squared"
+                      data-toggle="tooltip"
+                      title="Clear all filters"
+                    />
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -1494,5 +1498,9 @@ export default Vue.extend({
 .visible-menu {
   display: block;
   padding: 10px 5px 5px 10px;
+}
+
+.flex {
+  display: flex;
 }
 </style>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -146,7 +146,7 @@ export default Vue.extend({
         booleanOperator: {
             get() { return store.booleanOperator; },
             set(value) { store.booleanOperator = value; }
-        },
+        }
     },
     watch: {
         selectedSuperpixel() {
@@ -308,7 +308,7 @@ export default Vue.extend({
                     return store.filterBy.includes(`reviewer_${id}`);
                 }));
             }
-            //Filter by comparison
+            // Filter by comparison
             if (!!this.firstComparison && !!this.booleanOperator) {
                 // Select the appropriate comparison function
                 const op = this.booleanOperator === 'matches' ? (a, b) => a === b : (a, b) => a !== b;
@@ -316,7 +316,7 @@ export default Vue.extend({
                 // If no second option is selected we should compare the first selection
                 // to all remaining options. Otherwise just compare to the second selection.
                 let [key1, key2, userID1] = _.without(['label', 'review', 'prediction'], key0);
-                if (!!this.secondComparison) {
+                if (this.secondComparison) {
                     [key1, userID1, key2] = this.secondComparison.split('_');
                 }
 
@@ -338,7 +338,7 @@ export default Vue.extend({
                         // As we support more complex options to add/remove/rename categories across epochs the
                         // predictions categories and labels categories have a higher chance of diverging and we
                         // shouldn't assume the same order in both lists. Compare label values instead.
-                        values[idx] = !!values[idx] ? values[idx].label : values[idx];
+                        values[idx] = values[idx] ? values[idx].label : values[idx];
                     });
                     return (!!values[0] && !!values[1] && op(values[0], values[1])) ||
                            (!!values[0] && !!values[2] && op(values[0], values[2]));
@@ -436,17 +436,17 @@ export default Vue.extend({
             if (!selection || selection === 'prediction') {
                 return selection;
             } else {
-                let [key, userID] = selection.split('_');
+                const [key, userID] = selection.split('_');
                 let user;
                 if (store.currentUser._id === userID) {
                     user = store.currentUser;
                 } else {
                     const superpixel = _.find(this.superpixelsForReview, (superpixel) => {
-                        if (!!superpixel.meta) {
+                        if (superpixel.meta) {
                             return (
-                              (!!superpixel.meta.reviewer && superpixel.meta.reviewer._id === userID) ||
+                                (!!superpixel.meta.reviewer && superpixel.meta.reviewer._id === userID) ||
                               (!!superpixel.meta.labeler && superpixel.meta.labeler._id === userID)
-                            )
+                            );
                         }
                         return false;
                     });
@@ -455,7 +455,7 @@ export default Vue.extend({
                         user = superpixel.meta.reviewer;
                     }
                 }
-                return `${user.firstName} ${user.lastName} ${key}s`
+                return `${user.firstName} ${user.lastName} ${key}s`;
             }
         }
     }
@@ -1035,7 +1035,10 @@ export default Vue.extend({
                 </div>
               </div>
               <label for="comp">Filter By Comparison</label>
-              <div id="comp" class="flex">
+              <div
+                id="comp"
+                class="flex"
+              >
                 <div
                   class="dropdown-dropup selector-with-button"
                   :style="{'width': '35%', 'position': 'relative'}"
@@ -1197,12 +1200,15 @@ export default Vue.extend({
                     type="button"
                     data-toggle="dropdown"
                   >
-                    {{ selectedComparisonText(secondComparison) || (!!firstComparison && !!booleanOperator ? 'Any' : '(None)')}}
+                    {{ selectedComparisonText(secondComparison) || (!!firstComparison && !!booleanOperator ? 'Any' : '(None)') }}
                     <span class="caret" />
                   </button>
                   <ul class="dropdown-menu">
                     <li>
-                      <div class="radio" :disabled="firstComparison === 'prediction'">
+                      <div
+                        class="radio"
+                        :disabled="firstComparison === 'prediction'"
+                      >
                         <label
                           for="any"
                           :class="['options', firstComparison === 'prediction' && 'disabled-label']"
@@ -1214,12 +1220,15 @@ export default Vue.extend({
                             :value="null"
                             class="hidden-radio"
                           >
-                            Any
+                          Any
                         </label>
                       </div>
                     </li>
                     <li>
-                      <div class="radio" :disabled="firstComparison === 'prediction'">
+                      <div
+                        class="radio"
+                        :disabled="firstComparison === 'prediction'"
+                      >
                         <label
                           for="prediction_2"
                           :class="['options', firstComparison === 'prediction' && 'disabled-label']"
@@ -1279,8 +1288,8 @@ export default Vue.extend({
                 </div>
                 <button
                   class="btn btn-danger btn-xs"
-                  :disabled="!this.firstComparison && !this.booleanOperator && !this.secondComparison"
-                  @click="() => {this.firstComparison = this.booleanOperator = this.secondComparison = null}"
+                  :disabled="!firstComparison && !booleanOperator && !secondComparison"
+                  @click="() => {firstComparison = booleanOperator = secondComparison = null}"
                 >
                   <i
                     class="icon-minus-squared"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -33,7 +33,9 @@ export default Vue.extend({
             observedSuperpixel: null,
             totalSuperpixels: 0,
             reviewTable: true,
-            openMenu: null
+            openMenu: null,
+            labelFlag: false,
+            predictionFlag: false
         };
     },
     computed: {
@@ -160,6 +162,14 @@ export default Vue.extend({
                 this.selectedSuperpixel = _.values(data)[0][0];
             }
             this.$nextTick(() => this.updateObserved());
+        },
+        firstComparison() {
+            this.labelFlag = !!this.firstComparison && !!this.booleanOperator;
+            this.predictionFlag = !!this.firstComparison && !!this.booleanOperator;
+        },
+        booleanOperator() {
+            this.labelFlag = !!this.firstComparison && !!this.booleanOperator;
+            this.predictionFlag = !!this.firstComparison && !!this.booleanOperator;
         }
     },
     mounted() {
@@ -365,6 +375,10 @@ export default Vue.extend({
         },
         catColorByIndex(index) {
             return store.categories[index].fillColor;
+        },
+        predColorByIndex(superpixel) {
+            const prediction = superpixel.prediction;
+            return superpixel.predictionCategories[prediction].fillColor;
         },
         triggerRetrain() {
             this.backboneParent.retrain();
@@ -1578,6 +1592,16 @@ export default Vue.extend({
                   :style="{'color': 'white'}"
                 />
               </div>
+              <i
+                v-if="superpixel.selectedCategory >= 0 && labelFlag"
+                class="flag-bottom-left icon-tag"
+                :style="{'color': catColorByIndex(superpixel.selectedCategory)}"
+              />
+              <i
+                v-if="superpixel.prediction >= 0 && predictionFlag"
+                class="flag-bottom-right icon-lightbulb"
+                :style="{'color': predColorByIndex(superpixel)}"
+              />
               <input
                 v-show="selectingSuperpixels"
                 v-model="selectedReviewSuperpixels"
@@ -1792,6 +1816,36 @@ export default Vue.extend({
   float: left;
   width: 25px;
   top: -2px;
+}
+
+.flag-top-left {
+  position: absolute;
+  top: -2px;
+  z-index: 100;
+  font-size: 16px;
+  border-radius: 18px;
+  background-color: white;
+  left: -2px;
+}
+
+.flag-bottom-left {
+  position: absolute;
+  bottom: -2px;
+  z-index: 100;
+  font-size: 16px;
+  border-radius: 18px;
+  background-color: white;
+  left: -2px;
+}
+
+.flag-bottom-right {
+  position: absolute;
+  bottom: -2px;
+  z-index: 100;
+  font-size: 16px;
+  border-radius: 18px;
+  background-color: white;
+  right: -2px;
 }
 
 .h-superpixel-card {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -549,7 +549,7 @@ export default Vue.extend({
             <label for="groupby">Group By</label>
             <div
               id="groupby"
-              class="dropdown-dropup"
+              class="dropdown-dropup selector-with-button"
             >
               <button
                 class="btn btn-block btn-default dropdown-toggle dropdown-button"
@@ -584,6 +584,17 @@ export default Vue.extend({
                   </div>
                 </li>
               </ul>
+              <button
+                class="btn btn-danger btn-xs"
+                :disabled="groupBy === 0"
+                @click="groupBy === 0"
+              >
+                <i
+                  class="icon-minus-squared"
+                  data-toggle="tooltip"
+                  title="Clear grouping"
+                />
+              </button>
             </div>
           </div>
           <div>
@@ -626,7 +637,19 @@ export default Vue.extend({
                 </li>
               </ul>
               <button
-                class="btn btn-info btn-sm"
+                class="btn btn-danger btn-xs"
+                :style="{'margin-right': '3px'}"
+                :disabled="sortBy === 0"
+                @click="sortBy === 0"
+              >
+                <i
+                  class="icon-minus-squared"
+                  data-toggle="tooltip"
+                  title="Clear sort"
+                />
+              </button>
+              <button
+                class="btn btn-info btn-xs"
                 @click="sortAscending = !sortAscending"
               >
                 <i
@@ -713,7 +736,7 @@ export default Vue.extend({
                   </ul>
                 </div>
                 <button
-                  class="btn btn-danger btn-sm"
+                  class="btn btn-danger btn-xs"
                   :disabled="!filterOptions.Slides.some(name => filterBy.includes(name))"
                   @click="removeFilters(filterOptions.Slides)"
                 >

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -50,7 +50,10 @@ const store = Vue.observable({
     filterBy: ['no review'],
     previewSize: 0.5,
     cardDetails: [],
-    reviewedSuperpixels: 0
+    reviewedSuperpixels: 0,
+    firstComparison: null,
+    secondComparison: null,
+    booleanOperator: null,
 });
 
 const previousCard = () => {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -53,7 +53,7 @@ const store = Vue.observable({
     reviewedSuperpixels: 0,
     firstComparison: null,
     secondComparison: null,
-    booleanOperator: null,
+    booleanOperator: null
 });
 
 const previousCard = () => {


### PR DESCRIPTION
This branch adds support for filtering by comparison. There are three new menus now:

- Selecting an item from the first or second menu disables it in the other menu (there is at most only one review, one prediction, and one user selection per superpixel)
- If an item is selected from the first menu and a boolean operator (`matches` or `differs from`) is selected the second menu option defaults to `Any`.
    - For example: `Predictions` + `matches` + `Any` returns all superpixels where the prediction matches either the user selection *or* the review (if there is one). This may need further discussion to make sure that is more helpful than confusing.
    - If a second comparison selection is made then just the two selections are compared
- As an initial pass at conveying more information this also adds (up to) two more flags when comparison filtering is applied: a tag icon in the lower left corner that is colored to reflect the user label and a lightbulb in the lower left corner colored to represent the predicted label. As always, position/styling/icons are open to discussion. I've added some additional ideas below:

![Screenshot from 2024-10-03 13-48-19](https://github.com/user-attachments/assets/718c4cd0-bf28-4528-9f77-01b98243cec1)

1. Keep the review flag shape & default blue color as the border, but color the user icon to reflect the review label's color. User selection and prediction flags are in the bottom with no border.
2. Keep the review flag shape, but change the border to black and color the user icon to reflect the review label's color. User selection and prediction flags are in the bottom with no border.
3. Change the review flag shape to match the circular new flags and drop the border. Color the user icon to reflect the review label's color. User selection and prediction icons are in the bottom with no border.
4. Keep the review flag shape but change the border color to black and but color the user icon to reflect the review label's color. User selection and prediction flags are stacked under the review flag.
5. Keep the review flag shape. User selection and prediction flags are stacked under the review flag. The border for each flag matches the label color.
6. Keep the review flag shape. User selection and prediction flags are stacked under the review flag. The border for all is the default blue color.

Or any combination of ideas.... (@jagstein @cooperlab @manthey @jeffbaumes)