### PR TITLE
Exclusions

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -33,7 +33,8 @@ const defaultAnnotationGroups = {
             lineColor: 'rgba(0, 0, 0, 1)',
             lineWidth: 2
         }
-    ]
+    ],
+    exclusions: []
 };
 
 /**
@@ -110,6 +111,13 @@ const ActiveLearningView = View.extend({
                 const newKey = JSON.parse(JSON.stringify(group.hotKey || oldKey));
                 assignHotkey(oldKey, newKey);
             });
+            // Map excluded label names to indices for internal use
+            let excluded = this.configAnnotationGroups.exclusions || [];
+            excluded = _.map(excluded, (l) => {
+                const idx = _.findIndex([...this.categoryMap.values()], (c) => c.label === l);
+                return idx === -1 ? null : idx - 1;
+            });
+            store.exclusions = _.reject(excluded, (v) => !_.isNumber(v));
 
             return this.fetchFoldersAndItems();
         });
@@ -129,6 +137,9 @@ const ActiveLearningView = View.extend({
             this.categoryMap.set(category.label, category);
         });
         this.histomicsUIConfig.annotationGroups.groups = [...groups.values()];
+        // Map excluded label indices to string names for readability
+        const excluded = _.map(store.exclusions, (idx) => store.categories[idx + 1].label);
+        this.histomicsUIConfig.annotationGroups.exclusions = excluded;
 
         // Update the config file
         restRequest({

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -681,7 +681,7 @@ const ActiveLearningView = View.extend({
                 jobId: this.lastRunJobId,
                 randominput: false,
                 train: true,
-                exclude: excluded
+                exclude: JSON.stringify(excluded)
             }
         }).done((job) => {
             store.page = 0;

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -662,13 +662,15 @@ const ActiveLearningView = View.extend({
         const data = this.generateClassificationJobData();
         data.jobId = this.lastRunJobId;
         data.randomInput = false;
+        const excluded = _.map(store.exclusions, (idx) => store.categories[idx + 1].label);
         restRequest({
             method: 'POST',
             url: `slicer_cli_web/${this.activeLearningJobUrl}/rerun`,
             data: {
                 jobId: this.lastRunJobId,
                 randominput: false,
-                train: true
+                train: true,
+                exclude: excluded
             }
         }).done((job) => {
             store.page = 0;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -237,7 +237,7 @@ export default Vue.extend({
     position: absolute;
     top: 5px;
     left: 5px;
-    width: 400px;
+    width: 415px;
     border-radius: 5px;
     box-shadow: 3px 3px 5px 2px rgba(0,0,0,.5);
     padding: 5px;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -651,6 +651,16 @@ export default Vue.extend({
                     title="Change label color"
                   />
                 </td>
+                <td>
+                  <button
+                    class="btn btn-xs"
+                    :style="{'background-color': 'transparent'}"
+                    data-toggle="tooltip"
+                    title="Exclude from training"
+                  >
+                    <i class="icon-block" />
+                  </button>
+                </td>
                 <td v-if="mode === viewMode.Labeling">
                   <input
                     v-model="checkedCategories"
@@ -701,7 +711,10 @@ export default Vue.extend({
         v-if="!currentCategoryFormValid || !currentLabelsValid"
         class="h-error-messages"
       >
-        <ul v-if="currentFormErrors.length > 0 || currentLabelingErrors.length > 0">
+        <ul
+          v-if="currentFormErrors.length > 0 || currentLabelingErrors.length > 0"
+          :style="{'padding-left': '10px'}"
+        >
           <li
             v-for="error in currentFormErrors"
             :key="error"
@@ -757,7 +770,7 @@ export default Vue.extend({
     position: absolute;
     top: 60px;
     left: 5px;
-    width: 400px;
+    width: 415px;
     display: flex;
     flex-direction: column;
     background-color: #fff;
@@ -835,7 +848,6 @@ tr:hover .editing-icons {
 }
 
 .h-error-messages {
-    padding-top: 25px;
     height: 100%;
 }
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -586,7 +586,7 @@ export default Vue.extend({
                 v-for="(key, index) in Object.keys(labeledSuperpixelCounts)"
                 :key="index"
                 :class="{'h-selected-row': categoryIndex === index && mode === viewMode.Labeling}"
-                :style="[exclusions.includes(index) && {'color': 'red'}]"
+                :style="[exclusions.includes(index) && {'color': 'red', 'font-weight': 'bold'}]"
                 @click="selectCategory(index)"
               >
                 <td v-if="editingHotkey === index">
@@ -667,18 +667,20 @@ export default Vue.extend({
                   />
                 </td>
                 <td>
-                  <button
-                    class="btn btn-xs"
-                    :style="{'background-color': 'transparent'}"
-                    data-toggle="tooltip"
-                    title="Exclude from training"
-                    @click="updateExclusions(index)"
-                  >
-                    <i
-                      class="icon-block"
-                      :style="[exclusions.includes(index) && {'color': 'red'}]"
-                    />
-                  </button>
+                  <div :class="[!exclusions.includes(index) && 'editing-icons']">
+                    <button
+                      class="btn btn-xs"
+                      :style="{'background-color': 'transparent'}"
+                      data-toggle="tooltip"
+                      :title="exclusions.includes(index) ? 'Excluded from training' : 'Exclude from training'"
+                      @click="updateExclusions(index)"
+                    >
+                      <i
+                        class="icon-block"
+                        :style="[exclusions.includes(index) && {'color': 'red'}]"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td v-if="mode === viewMode.Labeling">
                   <input

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -118,6 +118,9 @@ export default Vue.extend({
         },
         activeLearningSteps() {
             return activeLearningSteps;
+        },
+        exclusions() {
+            return store.exclusions;
         }
     },
     watch: {
@@ -207,6 +210,9 @@ export default Vue.extend({
                     this.$nextTick(() => el.focus());
                 }
             }
+        },
+        exclusions() {
+            store.backboneParent.updateHistomicsYamlConfig();
         }
     },
     mounted() {
@@ -488,6 +494,14 @@ export default Vue.extend({
             this.currentHotkeyInput = this.parseUserHotkeys(event);
             this.commitHotkeyChange();
         },
+        updateExclusions(index) {
+            if (store.exclusions.includes(index)) {
+                const pos = store.exclusions.indexOf(index);
+                store.exclusions.splice(pos, 1);
+            } else {
+                store.exclusions.push(index);
+            }
+        },
         /**********************************
          * USE BACKBONE CONTAINER METHODS *
          **********************************/
@@ -572,6 +586,7 @@ export default Vue.extend({
                 v-for="(key, index) in Object.keys(labeledSuperpixelCounts)"
                 :key="index"
                 :class="{'h-selected-row': categoryIndex === index && mode === viewMode.Labeling}"
+                :style="[exclusions.includes(index) && {'color': 'red'}]"
                 @click="selectCategory(index)"
               >
                 <td v-if="editingHotkey === index">
@@ -657,8 +672,12 @@ export default Vue.extend({
                     :style="{'background-color': 'transparent'}"
                     data-toggle="tooltip"
                     title="Exclude from training"
+                    @click="updateExclusions(index)"
                   >
-                    <i class="icon-block" />
+                    <i
+                      class="icon-block"
+                      :style="[exclusions.includes(index) && {'color': 'red'}]"
+                    />
                   </button>
                 </td>
                 <td v-if="mode === viewMode.Labeling">

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -26,6 +26,7 @@ const store = Vue.observable({
     currentUser: null,
     epoch: -1,
     userNames: {},
+    exclusions: [],
     /*********
      * UI
      *********/


### PR DESCRIPTION
Relies on #150 - requires rebase on master once #150 is merged in.

- Adds a new column to the labeling dialog that allows users to exclude a label from training
- Excluded labels are highlighted in red
- Exclusions are also stored in the histomics config file so that they are remembered between sessions. This would also allow users to easily modify their config file manually to update their exclusions list. If this is not the best place to save this information we could instead explore moving the list to the annotation metadata (with the review/label tracking information).

![image](https://github.com/user-attachments/assets/e14f6cc0-a5ad-462e-a5b4-2f97cd37a988)