### PR TITLE
Use consistent terminology

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -194,7 +194,7 @@ export default Vue.extend({
             :value="categoryIndex(category.label)"
             class="h-superpixel-select-option"
           >
-            Class: {{ category.label }}
+            Label: {{ category.label }}
           </option>
         </select>
       </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -26,7 +26,7 @@ export default Vue.extend({
             showLabelingContainer: true,
             editingLabel: -1,
             checkedCategories: [],
-            currentCategoryLabel: 'New Category',
+            currentCategoryLabel: 'New Label',
             currentCategoryFillColor: getFillColor(0),
             editingHotkey: -1,
             currentHotkeyInput: []
@@ -52,7 +52,7 @@ export default Vue.extend({
             const errors = [];
             const counts = _.map(Object.keys(this.labeledSuperpixelCounts), (entry) => this.labeledSuperpixelCounts[entry].count);
             if (_.filter(counts, (count) => count > 0).length < 2) {
-                errors.push('You must label superpixels for at least two different categories.');
+                errors.push('You must label superpixels for at least two different labels.');
             }
             return errors;
         },
@@ -222,7 +222,7 @@ export default Vue.extend({
          *************************/
         addCategory(newName, newFillColor) {
             if (_.isUndefined(newName)) {
-                newName = 'New Category';
+                newName = 'New Label';
             }
             if (_.isUndefined(newFillColor)) {
                 const idx = store.categoriesAndIndices.length || 0;
@@ -320,7 +320,7 @@ export default Vue.extend({
             this.$emit('combine');
         },
         mergeCategory(newLabel, newFillColor) {
-            this.addCategory('Merged Categories', newFillColor);
+            this.addCategory('Merged Labels', newFillColor);
             this.combineCategories(this.checkedCategories, true);
             _.last(store.categoriesAndIndices).category.label = this.enforceUniqueName(newLabel);
         },
@@ -347,9 +347,9 @@ export default Vue.extend({
                     return _.contains(predictions, labels[i + 1].label);
                 });
             });
-            const predictionsWarning = `Deleting a category with predictions will
+            const predictionsWarning = `Deleting a label with predictions will
                                         immediately force retraining to run.`;
-            const labelingWarning = `Deleting categories cannot be undone.`;
+            const labelingWarning = `Deleting labels cannot be undone.`;
             const message = `${hasPredictions ? predictionsWarning : labelingWarning}
                             Are you sure you want to delete all ${labelCounts} labeled
                             superpixels?`;
@@ -669,7 +669,7 @@ export default Vue.extend({
                 class="btn btn-danger btn-xs"
                 :disabled="checkedCategories.length < 1"
                 data-toggle="tooltip"
-                title="Delete category"
+                title="Delete label"
                 @click="() => deleteCategory(checkedCategories)"
               >
                 <i class="icon-trash" />
@@ -694,7 +694,7 @@ export default Vue.extend({
             :disabled="!currentCategoryFormValid"
             @click="() => addCategory()"
           >
-            <i class="icon-plus" /> Add Category
+            <i class="icon-plus" /> Add Label
           </button>
         </div>
       </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -507,7 +507,7 @@ export default Vue.extend({
           href="#categories"
           @click="categoriesPanelCollapsed = !categoriesPanelCollapsed"
         >
-          Categories
+          Labels
           <i
             v-if="categoriesPanelCollapsed"
             class="icon-angle-down"
@@ -992,7 +992,7 @@ export default Vue.extend({
                       type="checkbox"
                       value="selectedCategory"
                     >
-                    Class Name
+                    Label Name
                   </label>
                 </li>
                 <li>
@@ -1126,7 +1126,7 @@ export default Vue.extend({
                 data-toggle="dropdown"
                 :disabled="selectedReviewSuperpixels.length < 1"
               >
-                Change Class
+                Change Label
                 <span class="caret" />
               </button>
               <ul

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningMergeConfirmation.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningMergeConfirmation.vue
@@ -13,7 +13,7 @@ export default Vue.extend({
     data() {
         return {
             currentCategoryFillColor: 'rgba(0, 0, 0, 0.5)',
-            categoryName: 'Merged Categories'
+            categoryName: 'Merged Labels'
         };
     },
     computed: {
@@ -22,8 +22,8 @@ export default Vue.extend({
             const labelCounts = _.reduce([...store.selectedLabels.values()], (acc, selected) => {
                 return acc + selected.count;
             }, 0);
-            const message = `This will combine ${numCategories} categories into
-                          one category containing all ${labelCounts} labeled
+            const message = `This will combine ${numCategories} labels into
+                          one label containing all ${labelCounts} labeled
                           superpixels.`;
             return message;
         },
@@ -80,11 +80,11 @@ export default Vue.extend({
             &times;
           </button>
           <h4 class="modal-title">
-            Merge Categories
+            Merge Labels
           </h4>
         </div>
         <div class="modal-body">
-          <p> WARNING: Merging categories cannot be undone. {{ warningMessage }} </p>
+          <p> WARNING: Merging labels cannot be undone. {{ warningMessage }} </p>
           <div class="form-group h-form-inputs">
             <label for="usr">New Name:</label>
             <input

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -312,7 +312,7 @@ export default Vue.extend({
                 const fillColor = getFillColor(store.categoriesAndIndices.length);
                 store.categoriesAndIndices.push({
                     category: {
-                        label: 'New Category',
+                        label: 'New Label',
                         fillColor,
                         strokeColor: boundaryColor
                     },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/constants.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/constants.js
@@ -51,14 +51,14 @@ export const activeLearningSteps = {
 export const groupByOptions = {
     0: '(None)',
     1: 'Slide',
-    2: 'Class',
+    2: 'Label',
     3: 'Agree/Disagree'
 };
 
 export const sortByOptions = {
     0: '(None)',
     1: 'Slide',
-    2: 'Class',
+    2: 'Label',
     3: 'Agree/Disagree',
     4: 'Confidence',
     5: 'Certainty'

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -123,7 +123,7 @@ const updatePixelmapLayerStyle = () => {
                     d += 1;
                 }
                 if (d < 0 || d >= store.categories.length) {
-                    console.warn(`No category found at index ${d} in the category map.`);
+                    console.warn(`No label found at index ${d} in the label map.`);
                     return 'rgba(0, 0, 0, 0)';
                 }
                 const category = store.categories[d];


### PR DESCRIPTION
Rather than a mix of category/class/label, use the term "label" everywhere in the UI.

Addresses the second half of #148.