### PR TITLE
Drop the review count badge from the review tab

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -818,12 +818,6 @@ const ActiveLearningView = View.extend({
             url: `annotation/${annotation.id}/metadata`,
             data: JSON.stringify({ metadata }),
             contentType: 'application/json'
-        }).then(() => {
-            store.reviewedSuperpixels = _.reduce(_.values(this.annotationsByImageId), (acc, ann) => {
-                const attrs = ann.labels.get('annotation').attributes;
-                return acc + _.size(_.pick(attrs.metadata, (v) => v.reviewEpoch === store.epoch));
-            }, 0);
-            return store.reviewedSuperpixels;
         });
     },
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningToolBar.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningToolBar.vue
@@ -17,9 +17,6 @@ export default Vue.extend({
         },
         activeLearningSteps() {
             return activeLearningSteps;
-        },
-        reviewedSuperpixels() {
-            return store.reviewedSuperpixels;
         }
     },
     methods: {
@@ -65,10 +62,6 @@ export default Vue.extend({
         @click="changeMode(viewMode.Review)"
       >
         <i class="icon-th" /> Review
-        <span
-          v-if="reviewedSuperpixels > 0"
-          class="badge"
-        >{{ reviewedSuperpixels }}</span>
       </button>
     </div>
   </div>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -50,7 +50,6 @@ const store = Vue.observable({
     filterBy: ['no review'],
     previewSize: 0.5,
     cardDetails: [],
-    reviewedSuperpixels: 0,
     firstComparison: null,
     secondComparison: null,
     booleanOperator: null


### PR DESCRIPTION
As it stands the badge is not really clear in its purpose and may only serve to create more confusion. If there is a need in the future we can re-introduce this with further discussion.

Fixes #149 