### PR TITLE
Pull fewer tiles when switching view area

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -284,6 +284,12 @@ export default Vue.extend({
                 center.y += offset * height;
                 this.viewerWidget.viewer.center(center);
             }
+            this.viewerWidget.viewer.layers().forEach((l) => {
+                if (l.activeTiles) {
+                    l.reset();
+                }
+            });
+            this.viewerWidget.viewer.draw();
             this.boundingBoxFeature.data([[
                 [bbox[0], bbox[1]], [bbox[2], bbox[1]], [bbox[2], bbox[3]], [bbox[0], bbox[3]]
             ]]);


### PR DESCRIPTION
When switching bounding boxes, reset the tile layer's visible tile records.

We might want to avoid doing this if we didn't switch image, as some of the lower level tiles will be in common between the view areas and the upper level tiles could be adjacent in some cases.