### PR TITLE
Fix delete merge

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -496,6 +496,7 @@ const ActiveLearningView = View.extend({
      */
     getSortedSuperpixelIndices() {
         this.superpixelPredictionsData = [];
+        store.predictionCounts = new Array(this.categoryMap.size - 1).fill(0);
         _.forEach(Object.keys(this.annotationsByImageId), (imageId) => {
             if (!this.annotationsByImageId[imageId].predictions) {
                 // New images may not have any predictions
@@ -530,6 +531,7 @@ const ActiveLearningView = View.extend({
                     meta: metadata[index],
                     reviewValue: metadata[index] ? metadata[index].reviewValue : null
                 };
+                store.predictionCounts[prediction.prediction] += 1;
                 this.superpixelPredictionsData.push(prediction);
             });
         });

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -341,17 +341,7 @@ export default Vue.extend({
 
             // We need to determine if any of the deleted categories have predictions associated with them.
             // If they do this will automatically trigger retraining so the user needs to be warned.
-            let hasPredictions = false;
-            _.forEach(Object.values(store.annotationsByImageId), (annotation) => {
-                if (!_.has(annotation, 'predictions')) {
-                    return;
-                }
-                const labels = annotation.labels.get('annotation').elements[0].categories;
-                const predictions = _.pluck(annotation.predictions.get('annotation').elements[0].categories, 'label');
-                hasPredictions = _.some(indices, (i) => {
-                    return _.contains(predictions, labels[i + 1].label);
-                });
-            });
+            const hasPredictions = this.checkedCategories.some((i) => store.predictionCounts[i - 1] > 0);
             const predictionsWarning = `Deleting a label with predictions will
                                         immediately force retraining to run.`;
             const labelingWarning = `Deleting labels cannot be undone.`;
@@ -361,7 +351,7 @@ export default Vue.extend({
             confirm({
                 title: 'Warning',
                 text: message,
-                yesText: 'Delete Selected',
+                yesText: `Delete Selected${ hasPredictions ? ' and Retrain' : ''}`,
                 confirmCallback: () => {
                     this.combineCategories(indices, false);
                     if (hasPredictions) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -54,7 +54,8 @@ const store = Vue.observable({
     cardDetails: [],
     firstComparison: null,
     secondComparison: null,
-    booleanOperator: null
+    booleanOperator: null,
+    predictionCounts: [],
 });
 
 const previousCard = () => {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -55,7 +55,7 @@ const store = Vue.observable({
     firstComparison: null,
     secondComparison: null,
     booleanOperator: null,
-    predictionCounts: [],
+    predictionCounts: []
 });
 
 const previousCard = () => {


### PR DESCRIPTION
Previously deleting or merging categories had become essentially unusable - the UI would often freeze. This adds a handful of improvements to fix this issue:
- Replace lodash functions with native JS where possible
- Only look at metadata and labels that we know might be affected
- Handle delete and merge in one loop rather than two separate loops