### PR TITLE
Additional speedups

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -112,6 +112,11 @@ const ActiveLearningView = View.extend({
                 const newKey = JSON.parse(JSON.stringify(group.hotKey || oldKey));
                 assignHotkey(oldKey, newKey);
             });
+
+            // Create the guidedLabeleling object if it does not exist
+            'guidedLabelingUI' in this.histomicsUIConfig || (this.histomicsUIConfig.guidedLabelingUI = {});
+            store.strokeOpacity = this.histomicsUIConfig.guidedLabelingUI.borderOpacity || 1.0;
+
             // Map excluded label names to indices for internal use
             let excluded = this.configAnnotationGroups.exclusions || [];
             excluded = _.map(excluded, (l) => {
@@ -138,6 +143,10 @@ const ActiveLearningView = View.extend({
             this.categoryMap.set(category.label, category);
         });
         this.histomicsUIConfig.annotationGroups.groups = [...groups.values()];
+
+        // Write the opacity value as a float
+        this.histomicsUIConfig.guidedLabelingUI.borderOpacity = parseFloat(store.strokeOpacity);
+
         // Map excluded label indices to string names for readability
         const excluded = _.map(store.exclusions, (idx) => store.categories[idx + 1].label);
         this.histomicsUIConfig.annotationGroups.exclusions = excluded;

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -454,6 +454,7 @@ const ActiveLearningView = View.extend({
 
         // Replace categories
         pixelmapElement.categories = categories;
+        this.saveAnnotations([imageId], false);
     },
 
     /**
@@ -489,7 +490,6 @@ const ActiveLearningView = View.extend({
                 this.updateCategoriesAndData(labelPixelmapElement, imageId);
             }
         });
-        this.saveAnnotations(Object.keys(this.annotationsByImageId), true);
     },
 
     /**
@@ -634,6 +634,7 @@ const ActiveLearningView = View.extend({
     }, 500, true),
 
     applyReviews() {
+        const imageIds = [];
         _.forEach(_.values(this.annotationsByImageId), (values) => {
             if (!values.labels) {
                 // Newly added images may not have labels yet
@@ -644,11 +645,14 @@ const ActiveLearningView = View.extend({
                 _.forEach(Object.entries(annotation.attributes.metadata), ([k, v]) => {
                     if (_.isNumber(v.reviewValue) && v.reviewEpoch >= v.labelEpoch) {
                         annotation.elements[0].values[k] = v.reviewValue;
+                        if (!imageIds.includes(annotation.itemId)) {
+                            imageIds.push(annotation.itemId);
+                        }
                     }
                 });
             }
         });
-        this.saveAnnotations(Object.keys(this.annotationsByImageId), true);
+        this.saveAnnotations(imageIds, false);
     },
 
     retrain(goToNextStep) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -5,7 +5,6 @@ import ActiveLearningFilmStripCard from './ActiveLearningFilmStripCard.vue';
 import ActiveLearningStats from './ActiveLearningStats.vue';
 import { store, updateSelectedPage } from '../store.js';
 import { viewMode } from '../constants';
-import { updateMetadata } from '../utils.js';
 
 export default {
     components: {
@@ -64,18 +63,18 @@ export default {
             updateSelectedPage();
             store.selectedIndex = 0;
         },
-        agreeAll() {
+        updateAll(usePrediction) {
             _.forEach(store.superpixelsToDisplay, (superpixel) => {
                 // Account for missing "default" category in predictions
-                superpixel.selectedCategory = superpixel.prediction + 1;
-                updateMetadata(superpixel, superpixel.prediction + 1, false);
+                const value = usePrediction ? superpixel.prediction + 1 : 0;
+                superpixel.selectedCategory = value;
             });
-            store.backboneParent.updateAnnotationMetadata(store.currentImageId);
+        },
+        agreeAll() {
+            this.updateAll(true);
         },
         resetAll() {
-            _.forEach(store.superpixelsToDisplay, (superpixel) => {
-                superpixel.selectedCategory = 0;
-            });
+            this.updateAll(false);
         },
         updatePageSize() {
             if (store.mode !== viewMode.Guided) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -115,27 +115,6 @@ export default Vue.extend({
         },
         mergeCategory(label, color) {
             this.activeLearningLabeling.mergeCategory(label, color);
-        },
-        saveAnnotations(imageIds, savePredictions) {
-            const idsToSave = _.isEmpty(imageIds) ? Object.keys(store.annotationsByImageId) : imageIds;
-            store.backboneParent.saveAnnotations(idsToSave, savePredictions);
-        },
-        synchronizeCategories(imageIds, savePredictions) {
-            // Keep the save annotations in sync with the local state
-            if (store.currentCategoryFormValid) {
-                _.forEach(Object.values(store.annotationsByImageId), (annotations) => {
-                    if (_.has(annotations, 'labels')) {
-                        const superpixelElement = annotations.labels.get('annotation').elements[0];
-                        if (superpixelElement) {
-                            const updatedCategories = JSON.parse(JSON.stringify(store.categories));
-                            superpixelElement.categories = updatedCategories;
-                        }
-                    }
-                });
-                this.saveAnnotations(imageIds, savePredictions);
-                updatePixelmapLayerStyle();
-                store.backboneParent.updateHistomicsYamlConfig();
-            }
         }
     }
 });
@@ -158,8 +137,6 @@ export default Vue.extend({
         ref="activeLearningSlideViewer"
         class="slide-viewer"
         :available-images="availableImages"
-        @synchronize="synchronizeCategories"
-        @save-annotations="saveAnnotations"
       />
       <!-- Current Slide Name -->
       <div class="h-category-form slide-name-container">
@@ -200,7 +177,6 @@ export default Vue.extend({
       <active-learning-labeling
         v-if="mode !== viewMode.Review"
         ref="activeLearningLabeling"
-        @synchronize="synchronizeCategories"
         @combine="combineCategories"
       />
       <!-- Merge Confirmation Dialog -->

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -1,6 +1,5 @@
 <script>
 import Vue from 'vue';
-import _ from 'underscore';
 
 import ActiveLearningInitialSuperpixels from './ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue';
 import ActiveLearningMergeConfirmation from './ActiveLearningSetup/ActiveLearningMergeConfirmation.vue';
@@ -12,7 +11,7 @@ import MouseAndKeyboardControls from './MouseAndKeyboardControls.vue';
 import ActiveLearningSlideViewer from './ActiveLearningSlideViewer.vue';
 
 import { viewMode, activeLearningSteps } from './constants';
-import { store, updatePixelmapLayerStyle, updateSelectedPage } from './store.js';
+import { store, updateSelectedPage } from './store.js';
 
 export default Vue.extend({
     components: {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -1,5 +1,6 @@
 <script>
 import Vue from 'vue';
+import _ from 'underscore';
 
 import ActiveLearningInitialSuperpixels from './ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue';
 import ActiveLearningMergeConfirmation from './ActiveLearningSetup/ActiveLearningMergeConfirmation.vue';

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -246,7 +246,7 @@ export default Vue.extend({
             this.viewerWidget.on('g:mouseUpAnnotationOverlay', this.clearPixelmapPaintValue);
             this.viewerWidget.viewer.interactor().removeAction(geo.geo_action.zoomselect);
             this.updateActionModifiers();
-            this.$emit('synchronize', [store.currentImageId], false);
+            updatePixelmapLayerStyle();
         },
         updateMapBoundsForSelection() {
             if (!this.viewerWidget || !this.viewerWidget.viewer || !store.superpixelsToDisplay.length) {
@@ -464,7 +464,7 @@ export default Vue.extend({
                 data = _.filter(data, (d, i) => i % 2 === 0);
             }
             superpixelElement.values = data;
-            this.$emit('save-annotations', [store.currentImageId], false);
+            store.backboneParent.saveAnnotations([store.currentImageId], false);
         },
         updateRunningLabelCounts(boundaries, index, newLabel, oldLabel) {
             const elementValueIndex = boundaries ? index / 2 : index;
@@ -505,7 +505,7 @@ export default Vue.extend({
         },
         combineCategoriesHandler() {
             this.drawPixelmapAnnotation();
-            this.$emit('save-annotations', [], true);
+            store.backboneParent.saveAnnotations(Object.keys(store.annotationsByImageId), true);
             this.updateConfig();
             store.backboneParent.getSortedSuperpixelIndices();
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -121,8 +121,9 @@ export default Vue.extend({
                 if (!store.changeLog.length) {
                     return;
                 }
-                this.changeLog.pop();
+                const superpixel = this.changeLog.pop();
                 this.drawPixelmapAnnotation();
+                store.backboneParent.saveAnnotations([superpixel.imageId], false);
             },
             deep: true
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/AnnotationOpacityControl.vue
@@ -6,72 +6,47 @@ import { store, updatePixelmapLayerStyle } from './store.js';
 export default {
     data() {
         return {
-            fillColor: 'rgba(0, 0, 0, 1)',
-            opacity: 1
+            fillColor: 'rgba(0, 0, 0, 1)'
         };
     },
     computed: {
-        config() {
-            if (store.backboneParent) {
-                return store.backboneParent.histomicsUIConfig || {};
-            }
-            return {};
-        },
-        folderId() {
-            if (store.backboneParent) {
-                return store.backboneParent.trainingDataFolderId;
-            }
-            return '';
-        },
-        opacitySlider() {
-            return store.strokeOpacity;
-        },
         categoryIndex() {
             return store.categoryIndex;
         },
         noOverlay() {
             return _.isNull(store.labelsOverlayLayer);
+        },
+        opacity: {
+            get() {
+                return store.strokeOpacity;
+            },
+            set(value) {
+                store.strokeOpacity = parseFloat(value);
+            }
         }
     },
     watch: {
-        opacitySlider() {
-            this.updateConfigData();
-            updatePixelmapLayerStyle();
-        },
         categoryIndex() {
             this.fillColor = store.categoriesAndIndices[this.categoryIndex].category.fillColor;
         },
         fillColor() {
-            if (store.opacitySlider === 0) {
+            if (store.strokeOpacity === 0) {
                 updatePixelmapLayerStyle();
             }
         },
-        folderId: {
-            handler(newId, oldId) {
-                if (newId && newId !== oldId) {
-                    this.getConfigData();
+        opacity: {
+            handler(newValue, oldValue) {
+                if (newValue === oldValue) {
+                    return;
                 }
+                this.updateConfigData();
+                updatePixelmapLayerStyle();
             },
             immediate: true
-        },
-        opacity(value) {
-            store.strokeOpacity = parseFloat(value);
         }
     },
     methods: {
-        getConfigData() {
-            if (!this.folderId) {
-                return;
-            }
-            const uiSettings = this.config.guidedLabelingUI || {};
-            if (uiSettings.borderOpacity) {
-                store.opacitySlider = uiSettings.borderOpacity;
-            }
-        },
         updateConfigData() {
-            const uiSettings = this.config.guidedLabelingUI || {};
-            uiSettings.borderOpacity = parseFloat(store.opacitySlider);
-            store.backboneParent.histomicsUIConfig.guidedLabelingUI = uiSettings;
             store.backboneParent.updateHistomicsYamlConfig();
         }
     }

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -60,6 +60,7 @@ export const updateMetadata = (superpixel, newCategory, isReview) => {
 export const debounce = (fn, wait, immediate = false) => {
     let lastArgs = null;
     let lastTimeout = null;
+    let lastCallTime = null;
 
     const debouncedFn = _.debounce(function (...args) {
         if (lastTimeout) {
@@ -67,13 +68,17 @@ export const debounce = (fn, wait, immediate = false) => {
             lastTimeout = null;
         }
         fn.apply(this, args);
+        lastCallTime = Date.now(); // Update last call timestamp
     }, wait, { leading: immediate });
 
     return function (...args) {
+        const now = Date.now();
+        const shouldRememberLastCall = lastCallTime && now - lastCallTime < wait;
+
         lastArgs = args;
         debouncedFn.apply(this, args);
 
-        if (!lastTimeout) {
+        if (!lastTimeout && shouldRememberLastCall) {
             lastTimeout = setTimeout(() => {
                 if (lastArgs) {
                     fn.apply(this, lastArgs);


### PR DESCRIPTION
The major fix in this branch is refactoring the "synchronize" function which was doing too much for most use cases. Now the paths for updating the config file, saving metadata, and saving annotations has been split into separate pathways that can be selected depending on the use case:
- Only update the config file when a label name, label color, border opacity, or exclusion is changed.
- Only synchronize labels across annotations when the label name or label color is changed
- Only save annotations when label name or color is changed, a superpixel is painted, or review is made.
- Only update the pixelmap if a superpixel is painted, border opacity is changed, or label color is changed.

Additionally, this branch:
- Fixes the opacity slider (appeared to no longer be working correctly)
- Improves the debounce utility function: The effort to remember the last call and ensure it is always processed meant that in cases where a function was called once it would now be called twice. We now take into account timing as well in order to make sure that the last function call is still always processed, but only if it hasn't already been.