### PR TITLE
Do not use the spread operator with large lists

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -280,16 +280,16 @@ export default Vue.extend({
                 }));
             }
             // Filter by review categories
-            const reviewResults = [];
+            let reviewResults = [];
             if (_.some(labels, (label) => store.filterBy.includes(`review_${label}`))) {
-                reviewResults.push(..._.filter(data, (superpixel) => {
+                reviewResults = reviewResults.concat(_.filter(data, (superpixel) => {
                     const { reviewValue, labelCategories } = superpixel;
                     const label = _.isNumber(reviewValue) ? labelCategories[reviewValue].label : '';
                     return store.filterBy.includes(`review_${label}`);
                 }));
             }
             if (store.filterBy.includes('no review')) {
-                reviewResults.push(..._.filter(data, (superpixel) => {
+                reviewResults = reviewResults.concat(_.filter(data, (superpixel) => {
                     return !superpixel.meta || !_.isNumber(superpixel.meta.reviewValue);
                 }));
             }


### PR DESCRIPTION
This provides a solution to the bug introduced by having too many arguments using the spread operator. For the sake of resolving this bug this is sufficient, but these filtering and sorting functions can be further improved. I will make those changes in a follow-up PR.