### PR TITLE
Don't assume labels exist when saving annotations

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -635,6 +635,10 @@ const ActiveLearningView = View.extend({
 
     applyReviews() {
         _.forEach(_.values(this.annotationsByImageId), (values) => {
+            if (!values.labels) {
+                // Newly added images may not have labels yet
+                return;
+            }
             const annotation = values.labels.get('annotation');
             if (annotation) {
                 _.forEach(Object.entries(annotation.attributes.metadata), ([k, v]) => {


### PR DESCRIPTION
Newly added images will not have labels associated with them yet.