### PR TITLE
Keep focus on last changed label

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -126,7 +126,6 @@ export default Vue.extend({
     },
     watch: {
         editingLabel() {
-            store.categoryIndex = this.editingLabel;
             if (this.editingLabel === -1) {
                 this.synchronizeCategories();
                 return;


### PR DESCRIPTION
Previously, renaming a label would force the focus to jump back the first label. Keep the focus on the most recently added/changed label instead.