### PR TITLE
Improve debounce

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -21,6 +21,8 @@ import { debounce } from '../vue/components/utils.js';
 import '../../stylesheets/body/learning.styl';
 
 const yaml = require('js-yaml');
+// Only necessary until we have native support for Promises with es6.
+// Used for Promise.all() and Promise.resolve() support.
 const Promise = require('bluebird');
 
 const epochRegex = /epoch (\d+)/i;

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -21,6 +21,7 @@ import { debounce } from '../vue/components/utils.js';
 import '../../stylesheets/body/learning.styl';
 
 const yaml = require('js-yaml');
+const Promise = require('bluebird');
 
 const epochRegex = /epoch (\d+)/i;
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -390,7 +390,7 @@ export default Vue.extend({
                 store.backboneParent.updateHistomicsYamlConfig();
                 store.backboneParent.saveAnnotations(Object.keys(store.annotationsByImageId));
             }
-        }, 500),
+        }),
         keydownListener(event) {
             if (event.target.type === 'text' && event.target.id !== 'category-hotkey') {
                 // User is typing, not using a hot key selector

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -1,6 +1,8 @@
 import { schemeTableau10 } from './constants';
 import { store } from './store';
 
+// Only necessary until we have native support for Promises with es6.
+// Used for Promise.all() and Promise.resolve() support.
 const Promise = require('bluebird');
 
 /**

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -1,7 +1,7 @@
-import _ from 'underscore';
-
 import { schemeTableau10 } from './constants';
 import { store } from './store';
+
+const Promise = require('bluebird');
 
 /**
  * Find the default color given the index of an item. Uses the
@@ -77,23 +77,23 @@ export const updateMetadata = (superpixel, newCategory, isReview) => {
  */
 
 export const debounce = (fn, debounceByArguments = false) => {
-    const inProgress = new Map();      // Track in-progress requests
-    const queuedRequests = new Map();  // Queue to ensure last request is always processed
+    const inProgress = new Map(); // Track in-progress requests
+    const queuedRequests = new Map(); // Queue to ensure last request is always processed
 
     function execute(...args) {
         const stringArgs = debounceByArguments ? JSON.stringify(args) : '';
         Promise.resolve(fn.apply(this, args))
-        .then((response) => response)
-        .finally(() => {
+            .then((response) => response)
+            .finally(() => {
             // Clean up the queue and update in-progress requests
-            inProgress.delete(stringArgs);
-            if (queuedRequests.has(stringArgs)) {
+                inProgress.delete(stringArgs);
+                if (queuedRequests.has(stringArgs)) {
                 // If we have queued requests continue processing them
-                queuedRequests.delete(stringArgs);
-                inProgress.set(stringArgs, true);
-                execute.apply(this, args);
-            }
-        })
+                    queuedRequests.delete(stringArgs);
+                    inProgress.set(stringArgs, true);
+                    execute.apply(this, args);
+                }
+            });
     }
 
     return function (...args) {
@@ -111,4 +111,4 @@ export const debounce = (fn, debounceByArguments = false) => {
             queuedRequests.set(stringArgs);
         }
     };
-}
+};

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -50,6 +50,31 @@ export const updateMetadata = (superpixel, newCategory, isReview) => {
     }
 };
 
+/**
+ * Creates a debounced version of a given function, guaranteeing that only one
+ * instance of the function executes at a time for the same arguments. If a
+ * new call is made with the same arguments while a previous call is still in
+ * progress, the latest call is queued and executed after the in-progress
+ * call finishes. Newer calls replace queued calls so that intermediate calls
+ * are debounced.
+ *
+ * @param {Function} fn - The function to debounce.
+ * @param {boolean} [trackArguments=false] - If true, the function will track
+ *     calls based on arguments, ensuring separate queues for each unique
+ *     argument set. If false, all calls share a single queue regardless of
+ *     arguments.
+ * @returns {Function} - A debounced version of the provided function.
+ *
+ * @example
+ * const simulatedRestRequest = async (arg) => {
+ *     console.log("Processing:", arg);
+ *     await sleep(1000); // Simulate processing delay
+ * };
+ * const debouncedRequest = debounce(simulatedRestRequest, true);
+ * debouncedRequest("A"); // Should process immediately
+ * debouncedRequest("A"); // Should queue, processed after the first completes
+ * debouncedRequest("A"); // Should replace the previous queued request
+ */
 
 export const debounce = (fn, debounceByArguments = false) => {
     const inProgress = new Map();      // Track in-progress requests

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -51,12 +51,12 @@ export const updateMetadata = (superpixel, newCategory, isReview) => {
 };
 
 
-export const debounce = (fn, trackArguments = false) => {
+export const debounce = (fn, debounceByArguments = false) => {
     const inProgress = new Map();
     const queuedRequests = new Map();
 
     function execute(...args) {
-        const stringArgs = trackArguments ? JSON.stringify(args) : '';
+        const stringArgs = debounceByArguments ? JSON.stringify(args) : '';
         // add stringArgs to inProgress
         if (!inProgress.has(stringArgs)) {
             inProgress.set(stringArgs, true);
@@ -78,7 +78,7 @@ export const debounce = (fn, trackArguments = false) => {
     }
 
     return function (...args) {
-        const stringArgs = trackArguments ? JSON.stringify(args) : '';
+        const stringArgs = debounceByArguments ? JSON.stringify(args) : '';
         // if call not in progress
         if (!inProgress.has(stringArgs)) {
             // execute


### PR DESCRIPTION
This PR aims to provide an improved debounce function should handle the following:

- Wrapped functions are debounced if there is a previous call in progress
- Functions with "important" arguments are handled as a special case. A previous request is only considered to be "in progress" if it has identical arguments to the current call.
- The last call is always processed, even if it would have been debounced.

Fixes #165