### PR TITLE
Component lifecycles

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -45,11 +45,11 @@ export default {
             this.updateSelectedCard();
         }
     },
-    mounted() {
+    activated() {
         window.addEventListener('resize', () => { this.$nextTick(() => this.updatePageSize()); });
         this.$nextTick(() => this.updatePageSize());
     },
-    destroyed() {
+    deactivated() {
         window.removeEventListener('resize', () => { this.$nextTick(() => this.updatePageSize()); });
     },
     methods: {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -70,6 +70,14 @@ export default Vue.extend({
         },
         sortedSuperpixelIndices() {
             return store.sortedSuperpixelIndices;
+        },
+        currentComponent() {
+            if (store.mode === viewMode.Guided) {
+              return ActiveLearningFilmStrip;
+            } else if (store.mode === viewMode.Review) {
+              return ActiveLearningReviewContainer;
+            }
+            return null;
         }
     },
     watch: {
@@ -183,10 +191,10 @@ export default Vue.extend({
       <mouse-and-keyboard-controls v-if="mode !== viewMode.Review" />
       <!-- Opacity Slider -->
       <annotation-opacity-control v-if="mode !== viewMode.Review" />
-      <!-- Prediction Chips -->
-      <active-learning-film-strip v-if="mode === viewMode.Guided" />
-      <!-- Review View -->
-      <active-learning-review-container v-if="mode === viewMode.Review" />
+      <!-- Prediction Chips or Review View -->
+      <keep-alive>
+        <component :is="currentComponent"></component>
+      </keep-alive>
     </div>
   </div>
 </template>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -36,7 +36,14 @@ export default Vue.extend({
             openMenu: null,
             labelFlag: false,
             showFlags: false,
-            currentMetadata: null
+            currentMetadata: null,
+            groupBy: 0,
+            sortBy: 0,
+            previewSize: 0.5,
+            cardDetails: [],
+            firstComparison: null,
+            secondComparison: null,
+            booleanOperator: null,
         };
     },
     computed: {
@@ -112,37 +119,9 @@ export default Vue.extend({
                 return trimmed;
             });
         },
-        groupBy: {
-            get() { return store.groupBy; },
-            set(value) { store.groupBy = value; }
-        },
-        sortBy: {
-            get() { return store.sortBy; },
-            set(value) { store.sortBy = value; }
-        },
         filterBy: {
             get() { return store.filterBy; },
             set(value) { store.filterBy = value; }
-        },
-        previewSize: {
-            get() { return store.previewSize; },
-            set(value) { store.previewSize = value; }
-        },
-        cardDetails: {
-            get() { return store.cardDetails; },
-            set(value) { store.cardDetails = value; }
-        },
-        firstComparison: {
-            get() { return store.firstComparison; },
-            set(value) { store.firstComparison = value; }
-        },
-        secondComparison: {
-            get() { return store.secondComparison; },
-            set(value) { store.secondComparison = value; }
-        },
-        booleanOperator: {
-            get() { return store.booleanOperator; },
-            set(value) { store.booleanOperator = value; }
         },
         userNames() {
             return store.userNames;
@@ -254,7 +233,7 @@ export default Vue.extend({
             return _.sortBy(sorted, 'certainty');
         },
         sortSuperpixels(sorted) {
-            switch (store.sortBy) {
+            switch (this.sortBy) {
                 case 1:
                     sorted = this.sortBySlideName(sorted);
                     break;
@@ -433,7 +412,7 @@ export default Vue.extend({
             });
         },
         groupSuperpixels(data) {
-            switch (store.groupBy) {
+            switch (this.groupBy) {
                 case 1:
                     return this.groupBySlideName(data);
                 case 2:
@@ -507,7 +486,7 @@ export default Vue.extend({
             }
         },
         removeFilters(values) {
-            this.filterBy = _.without(this.filterBy, ...values);
+            store.filterBy = _.without(store.filterBy, ...values);
         },
         toggleOpenMenu(menu) {
             this.openMenu = this.openMenu === menu ? null : menu;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -172,7 +172,7 @@ export default Vue.extend({
             this.showFlags = !!this.firstComparison && !!this.booleanOperator;
         }
     },
-    mounted() {
+    activated() {
         // Support infinite scrolling
         this.scrollObserver = new IntersectionObserver((entries, observer) => {
             entries.forEach((entry) => {
@@ -221,7 +221,8 @@ export default Vue.extend({
         const allUsers = [...this.filterOptions.Labelers, ...this.filterOptions.Reviewers];
         _.uniq(allUsers).forEach((id) => store.backboneParent.getUser(id));
     },
-    destroyed() {
+    deactivated() {
+        this.selectedSuperpixel = null;
         const resizeHandle = document.querySelector('.resize-handle');
         resizeHandle.removeEventListener('mousedown', () => { this.isResizing = true; });
         document.removeEventListener('mousemove', this.mouseMove);

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -48,14 +48,7 @@ const store = Vue.observable({
     activeLearningStep: activeLearningSteps.InitialState,
     selectedLabels: new Map(),
     selectedReviewSuperpixels: [],
-    groupBy: 0,
-    sortBy: 0,
     filterBy: ['no review'],
-    previewSize: 0.5,
-    cardDetails: [],
-    firstComparison: null,
-    secondComparison: null,
-    booleanOperator: null,
     predictionCounts: []
 });
 


### PR DESCRIPTION
The `KeepAlive` component allows conditionally caching component instances when dynamically switching between components (i.e. toggling between Guided and Review mode). This means that there is still a time cost the first time loading either mode, but future toggles take ~0.5 seconds (down from ~5-6 secs).