### PR TITLE
Detect active learning

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/main.js
+++ b/wsi_superpixel_guided_labeling/web_client/main.js
@@ -4,7 +4,7 @@ import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
 import girderEvents from '@girder/core/events';
 
 import ActiveLearningView from './views/body/ActiveLearningView';
-import './views/itemList';
+import './views/itemAndFolderList';
 import './views/HeaderView';
 import './views/HeaderImageView';
 import * as WSISuperpixelGuidedLabeling from './index';

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -116,6 +116,9 @@ const ActiveLearningView = View.extend({
                 assignHotkey(oldKey, newKey);
             });
 
+            // Create the activeLearning flag if it does not exist
+            'activeLearning' in this.histomicsUIConfig || (this.histomicsUIConfig.activeLearning = true);
+
             // Create the guidedLabeleling object if it does not exist
             'guidedLabelingUI' in this.histomicsUIConfig || (this.histomicsUIConfig.guidedLabelingUI = {});
             store.strokeOpacity = this.histomicsUIConfig.guidedLabelingUI.borderOpacity || 1.0;
@@ -133,6 +136,9 @@ const ActiveLearningView = View.extend({
     },
 
     updateHistomicsYamlConfig: debounce(function () {
+        // Make sure the flag to enable active learning is set to true
+        this.histomicsUIConfig.activeLearning = true;
+
         const groups = new Map();
         this.categoryMap.clear(); // Keep the internal categoryMap in sync with changes
         _.forEach(store.categories, (category, index) => {

--- a/wsi_superpixel_guided_labeling/web_client/views/itemAndFolderList.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/itemAndFolderList.js
@@ -1,5 +1,6 @@
 import { wrap } from '@girder/core/utilities/PluginUtils';
 import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
+import FolderListWidget from '@girder/core/views/widgets/FolderListWidget';
 import _ from 'underscore';
 import { restRequest } from '@girder/core/rest';
 

--- a/wsi_superpixel_guided_labeling/web_client/views/itemAndFolderList.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/itemAndFolderList.js
@@ -40,7 +40,7 @@ wrap(ItemListWidget, 'render', function (render) {
     restRequest({
         url: `folder/${thisFolder.id}/yaml_config/.histomicsui_config.yaml`
     }).done((config) => {
-        if (config && config['activeLearning'] || metaKeySet) {
+        if ((config && config.activeLearning) || metaKeySet) {
             // Make sure the required folders exist
             createRequiredFolders(thisFolder.id);
             const largeImageItems = _.filter(this.collection.models, (model) => model.attributes.largeImage);
@@ -82,7 +82,7 @@ wrap(FolderListWidget, 'insertFolder', function (insertFolder) {
     restRequest({
         url: `folder/${folder.id}/yaml_config/.histomicsui_config.yaml`
     }).done((config) => {
-        if (config && config['activeLearning']) {
+        if (config && config.activeLearning) {
             createRequiredFolders(folder.id);
         }
     });

--- a/wsi_superpixel_guided_labeling/web_client/views/itemList.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/itemList.js
@@ -18,6 +18,8 @@ wrap(ItemListWidget, 'render', function (render) {
         return;
     }
 
+    // For backwards compatability also check the metadata keys
+    const metaKeySet = this.parentView.parentModel.get('meta').active_learning;
     restRequest({
         url: `folder/${thisFolder.id}/yaml_config/.histomicsui_config.yaml`
     }).done((config) => {

--- a/wsi_superpixel_guided_labeling/web_client/views/itemList.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/itemList.js
@@ -3,28 +3,45 @@ import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
 import _ from 'underscore';
 import { restRequest } from '@girder/core/rest';
 
+const specialFolders = ['Annotations', 'Models', 'Features'];
+
+/**
+ * When we view an item list, look for the histomicsui config file. Check that
+ * the activeLearning key is set to true and make sure there is at least one
+ * item present. If all criteria is met, add the "Active Learning" button.
+ */
 wrap(ItemListWidget, 'render', function (render) {
     render.call(this);
-    const activeLearningFolder = this.parentView.parentModel.get('meta').active_learning;
-    if (activeLearningFolder) {
-        const largeImageItems = _.filter(this.collection.models, (model) => model.attributes.largeImage);
-        // don't make the request if the button already exists
-        if (largeImageItems.length && !this.parentView.$el.find('.wsi-al-open').length) {
-            restRequest({
-                type: 'GET',
-                url: 'histomicsui/settings'
-            }).then((settings) => {
-                if (!this.parentView.$el.find('.wsi-al-open').length) {
-                    const webrootPath = settings['histomicsui.webroot_path'];
-                    const btnContainer = this.parentView.$el.find('.g-folder-header-buttons');
-                    btnContainer.prepend(
-                        `<a class="wsi-al-open btn btn-sm btn-primary" role="button" href="${webrootPath}#/active-learning?folder=${this.parentView.parentModel.id}" target="_blank">
-                            <i class="icon-link-ext"></i>Active Learning
-                        </a>`
-                    );
-                }
-                return 0;
-            });
-        }
+    const thisFolder = this.parentView.parentModel;
+    if (specialFolders.includes(thisFolder.attributes.name)) {
+        // Ignore the special Annotations, Models, and Features folders
+        return;
     }
+
+    restRequest({
+        url: `folder/${thisFolder.id}/yaml_config/.histomicsui_config.yaml`
+    }).done((config) => {
+        if (config && config['activeLearning'] || metaKeySet) {
+            const largeImageItems = _.filter(this.collection.models, (model) => model.attributes.largeImage);
+            // Don't make the request if the button already exists
+            if (largeImageItems.length && !this.parentView.$el.find('.wsi-al-open').length) {
+                restRequest({
+                    type: 'GET',
+                    url: 'histomicsui/settings'
+                }).then((settings) => {
+                    if (!this.parentView.$el.find('.wsi-al-open').length) {
+                        // Add the Active Learning button
+                        const webrootPath = settings['histomicsui.webroot_path'];
+                        const btnContainer = this.parentView.$el.find('.g-folder-header-buttons');
+                        btnContainer.prepend(
+                            `<a class="wsi-al-open btn btn-sm btn-primary" role="button" href="${webrootPath}#/active-learning?folder=${this.parentView.parentModel.id}" target="_blank">
+                                <i class="icon-link-ext"></i>Active Learning
+                            </a>`
+                        );
+                    }
+                    return 0;
+                });
+            }
+        }
+    });
 });


### PR DESCRIPTION
- When a folder is created:
    - Look for `histomicsui_config` file (walks up the chain of parent folders until the file is found)
    - If the file is found, looks for `activeLearning: true`
    - If the flag is found, then we automatically create the `Annotations`, `Models`, and `Features` folders
    - The exception to this is if we are *in* an `Annotations`, `Models`, or `Features` folder
- When a folder is opened:
    - Look for `histomicsui_config` file (walks up the chain of parent folders until the file is found)
    - If the file is found, looks for `activeLearning: true`
    - If the flag is found, then make sure the `Annotations`, `Models`, and `Features` folders exist
    - If the folders exist, check for any items
    - If there are items and no `Active Learning` button, create and add the button

Fixes #82