### PR TITLE
Use more efficient zoomAndCenter call

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -279,8 +279,7 @@ export default Vue.extend({
                 y: (bbox[1] + bbox[3]) / 2
             };
             // Draw bounding box around selected superpixel
-            this.viewerWidget.viewer.zoom(zoom - 1.5);
-            this.viewerWidget.viewer.center(center);
+            this.viewerWidget.viewer.zoomAndCenter(zoom - 1.5, center);
             if (store.mode === viewMode.Review) {
                 // Offset the center to fit in the visible image section
                 const { height } = this.viewerWidget.viewer.bounds();


### PR DESCRIPTION
A zoomAndCenter method was added to the geojs map.  

I'm making the assumption you are on a recent version of the DSA so it has geojs >= 1.14 (from 2025-1-7).