### PR TITLE
Filtering improvements

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -16,7 +16,7 @@ import ActiveLearningGlobalContainer from '../vue/components/ActiveLearningGloba
 import ActiveLearningToolBar from '../vue/components/ActiveLearningToolBar.vue';
 import { store, assignHotkey } from '../vue/components/store.js';
 import { activeLearningSteps } from '../vue/components/constants.js';
-import { debounce } from '../vue/components/utils.js';
+import { debounce, isValidNumber } from '../vue/components/utils.js';
 
 import '../../stylesheets/body/learning.styl';
 
@@ -129,7 +129,7 @@ const ActiveLearningView = View.extend({
                 const idx = _.findIndex([...this.categoryMap.values()], (c) => c.label === l);
                 return idx === -1 ? null : idx - 1;
             });
-            store.exclusions = _.reject(excluded, (v) => !_.isNumber(v));
+            store.exclusions = _.reject(excluded, (v) => !isValidNumber(v));
 
             return this.fetchFoldersAndItems();
         });
@@ -667,7 +667,7 @@ const ActiveLearningView = View.extend({
             const annotation = values.labels.get('annotation');
             if (annotation) {
                 _.forEach(Object.entries(annotation.attributes.metadata), ([k, v]) => {
-                    if (_.isNumber(v.reviewValue) && v.reviewEpoch >= v.labelEpoch) {
+                    if (isValidNumber(v.reviewValue) && v.reviewEpoch >= v.labelEpoch) {
                         annotation.elements[0].values[k] = v.reviewValue;
                         if (!imageIds.includes(annotation.itemId)) {
                             imageIds.push(annotation.itemId);

--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -404,7 +404,10 @@ const ActiveLearningView = View.extend({
                     promises.push(backboneModel.fetch().done(() => {
                         this.annotationsByImageId[imageId][key] = backboneModel;
                         if (key === 'labels') {
-                            this.updateAnnotationMetadata(imageId);
+                            const annotation = backboneModel.get('annotation');
+                            if (!_.has(annotation.attributes, 'metadata')) {
+                                annotation.attributes.metadata = {};
+                            }
                             this.saveAnnotationMetadata(imageId);
                             if (!this.availableImages.includes(imageId)) {
                                 this.availableImages.push(imageId);
@@ -836,23 +839,6 @@ const ActiveLearningView = View.extend({
             });
         }, 2000);
     },
-
-    /**
-     * Update the annotation metadata
-     */
-    updateAnnotationMetadata: debounce(function (imageId) {
-        const annotation = this.annotationsByImageId[imageId].labels;
-        const pixelmapElement = annotation.get('annotation').elements[0];
-        const attributes = annotation.get('annotation').attributes;
-        // Guarantee that the metadata object exists
-        const metadata = attributes.metadata || (attributes.metadata = {});
-        pixelmapElement.values.forEach((value, index) => {
-            if (value !== 0 && (!metadata[index] || !metadata[index].labeler)) {
-                index in metadata || (metadata[index] = {});
-                metadata[index].labeler = store.currentUser;
-            }
-        });
-    }),
 
     /**
      * Save the annotation metadata. Useful for when only the metadata has changed

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -5,6 +5,7 @@ import ActiveLearningFilmStripCard from './ActiveLearningFilmStripCard.vue';
 import ActiveLearningStats from './ActiveLearningStats.vue';
 import { store, updateSelectedPage } from '../store.js';
 import { viewMode } from '../constants';
+import { updateMetadata } from '../utils.js';
 
 export default {
     components: {
@@ -68,6 +69,8 @@ export default {
                 // Account for missing "default" category in predictions
                 const value = usePrediction ? superpixel.prediction + 1 : 0;
                 superpixel.selectedCategory = value;
+                updateMetadata(superpixel, value, false);
+                store.labelingChangeLog.push(superpixel);
             });
         },
         agreeAll() {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -3,7 +3,6 @@ import Vue from 'vue';
 import _ from 'underscore';
 
 import { store, nextCard } from '../store';
-import { updateMetadata } from '../utils';
 
 export default Vue.extend({
     props: ['index'],
@@ -113,9 +112,7 @@ export default Vue.extend({
 
             // Force computed values to update
             store.categoriesAndIndices = [...store.categoriesAndIndices];
-            updateMetadata(this.superpixelDecision, newValue, false);
-            store.backboneParent.updateAnnotationMetadata(store.currentImageId);
-            store.guidedChangeLog.push(this.superpixelDecision);
+            store.labelingChangeLog.push(this.superpixelDecision);
         },
         lastCategorySelected(categoryNumber) {
             if (!this.isSelected || typeof categoryNumber !== 'number') {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -3,6 +3,7 @@ import Vue from 'vue';
 import _ from 'underscore';
 
 import { store, nextCard } from '../store';
+import { updateMetadata } from '../utils';
 
 export default Vue.extend({
     props: ['index'],
@@ -112,6 +113,7 @@ export default Vue.extend({
 
             // Force computed values to update
             store.categoriesAndIndices = [...store.categoriesAndIndices];
+            updateMetadata(this.superpixelDecision, newValue, false);
             store.labelingChangeLog.push(this.superpixelDecision);
         },
         lastCategorySelected(categoryNumber) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -1,6 +1,5 @@
 <script>
 import Vue from 'vue';
-import _ from 'underscore';
 
 import ActiveLearningInitialSuperpixels from './ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue';
 import ActiveLearningMergeConfirmation from './ActiveLearningSetup/ActiveLearningMergeConfirmation.vue';
@@ -113,10 +112,6 @@ export default Vue.extend({
         store.pageSize = this.pageSize;
         store.categories = [...this.categoryMap.values()];
         store.currentImageId = Object.keys(this.imageNamesById)[0];
-
-        // Default to filtering out unlabeled superpixels
-        const cats = _.map(_.rest(store.categories), (cat) => `label_${cat.label}`);
-        store.filterBy = [...store.filterBy, ...cats];
 
         // We don't want to mount child components until the store has been updated
         this.storeReady = true;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -218,9 +218,7 @@ export default Vue.extend({
     },
     mounted() {
         if (store.mode === viewMode.Review) return;
-
         window.addEventListener('keydown', this.keydownListener);
-        console.log('event listener added');
     },
     methods: {
         /*************************
@@ -302,18 +300,15 @@ export default Vue.extend({
                         // If we can't find the superpixel, build our own.
                         superpixel = { imageId, selectedCategory: newValue, index };
                     }
-
                     if (labelIndices[imageId].has(index)) {
                         // A label is affected, update the value and the metadata
                         pixelmapElement.values[index] = newValue;
-                        // meta[index]['LabelValue'] = newValue;
                         updateMetadata(superpixel, newValue, false);
                     }
 
                     if (meta[index] && meta[index].reviewValue === oldValue) {
                         // A review is affected, update the metadata
                         const newValue = newValues[index];
-                        // meta[index]['ReviewValue'] = newValue;
                         updateMetadata(superpixel, newValue, true);
                     }
                 });

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -99,7 +99,6 @@ export default Vue.extend({
                 }
 
                 updateMetadata(this.superpixel, newCategory, true);
-                store.backboneParent.updateAnnotationMetadata(this.superpixel.imageId);
             }
         }
     },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -99,6 +99,7 @@ export default Vue.extend({
                 }
 
                 updateMetadata(this.superpixel, newCategory, true);
+                store.backboneParent.saveAnnotationMetadata(this.superpixel.imageId);
             }
         }
     },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewCard.vue
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import _ from 'underscore';
 
 import { store } from '../store';
-import { updateMetadata } from '../utils';
+import { isValidNumber, updateMetadata } from '../utils';
 
 export default Vue.extend({
     props: ['superpixel', 'previewSize', 'cardDetails', 'reviewValue'],
@@ -81,7 +81,7 @@ export default Vue.extend({
         },
         reviewerCategorySelection: {
             get() {
-                if (!_.isNumber(this.superpixel.reviewValue)) {
+                if (!isValidNumber(this.superpixel.reviewValue)) {
                     return this.superpixel.selectedCategory;
                 }
                 return this.superpixel.reviewValue;
@@ -95,7 +95,7 @@ export default Vue.extend({
                     // Index (newCategory) -1 indicates "Approve" or "Clear Review". If we are approving
                     // then we are setting the reviewValue to the selectedCategory. If we are clearing the
                     // review we are setting the reviewValue to null.
-                    newCategory = _.isNumber(this.superpixel.reviewValue) ? null : this.superpixel.selectedCategory;
+                    newCategory = isValidNumber(this.superpixel.reviewValue) ? null : this.superpixel.selectedCategory;
                 }
 
                 updateMetadata(this.superpixel, newCategory, true);

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -265,12 +265,11 @@ export default Vue.extend({
         sortByLabelCategory(sorted) {
             return _.sortBy(sorted, 'selectedCategory');
         },
-        sortByLabelPredictionAgreement(sorted) {
-            return _.sortBy(sorted, (superpixel) => {
-                const selected = superpixel.labelCategories[superpixel.selectedCategory];
-                const predicted = superpixel.predictionCategories[superpixel.prediction];
-                return selected.label === predicted.label;
-            });
+        sortByPredictionCategory(sorted) {
+            return _.sortBy(sorted, 'prediction');
+        },
+        sortByReviewCategory(sorted) {
+            return _.sortBy(sorted, 'reviewValue');
         },
         sortByConfidence(sorted) {
             return _.sortBy(sorted, 'confidence');
@@ -287,12 +286,15 @@ export default Vue.extend({
                     sorted = this.sortByLabelCategory(sorted);
                     break;
                 case 3:
-                    sorted = this.sortByLabelPredictionAgreement(sorted);
+                    sorted = this.sortByPredictionCategory(sorted);
                     break;
                 case 4:
-                    sorted = this.sortByConfidence(sorted);
+                    sorted = this.sortByReviewCategory(sorted);
                     break;
                 case 5:
+                    sorted = this.sortByConfidence(sorted);
+                    break;
+                case 6:
                     sorted = this.sortByCertainty(sorted);
                     break;
                 default:

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -173,12 +173,8 @@ export default Vue.extend({
                 if (!store.reviewChangeLog.length) {
                     return;
                 }
-                const changedSuperpixel = this.reviewChangeLog.pop();
+                const changedSuperpixel = store.reviewChangeLog.pop();
                 this.updateFilteredSortedGroupedSuperpixels(changedSuperpixel);
-                // All changes in this change log are label changes.
-                // Make sure the metadata is kept in sync.
-                updateMetadata(changedSuperpixel, changedSuperpixel.selectedCategory, false);
-                store.backboneParent.updateAnnotationMetadata(changedSuperpixel.imageId);
             },
             deep: true
         },
@@ -604,8 +600,6 @@ export default Vue.extend({
             this.selectedReviewSuperpixels.forEach((superpixel) => {
                 updateMetadata(superpixel, newValue, true);
             });
-            Object.keys(store.annotationsByImageId).forEach(
-                (imageId) => store.backboneParent.updateAnnotationMetadata(imageId));
             this.selectedReviewSuperpixels = [];
             this.selectingSuperpixels = false;
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -174,6 +174,10 @@ export default Vue.extend({
                 this.updateFilteredSortedGroupedSuperpixels(changedSuperpixel);
             },
             deep: true
+        },
+        sortAscending() {
+            Object.values(this.filteredSortedGroupedSuperpixels)
+                .map((sortedList) => sortedList.reverse());
         }
     },
     mounted() {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -1073,7 +1073,7 @@ export default Vue.extend({
                       >
                         <label
                           :for="`slide_${index}`"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             :id="`slide_${index}`"
@@ -1119,7 +1119,7 @@ export default Vue.extend({
                       >
                         <label
                           :for="`prediction_${index}`"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             :id="`prediction_${index}`"
@@ -1164,7 +1164,7 @@ export default Vue.extend({
                       <li>
                         <label
                           for="cat_0"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             id="cat_0"
@@ -1179,7 +1179,7 @@ export default Vue.extend({
                       <li>
                         <label
                           for="cat_has_label"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             id="cat_has_label"
@@ -1195,7 +1195,7 @@ export default Vue.extend({
                       >
                         <label
                           :for="`cat_${index + 1}`"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             :id="`cat_${index + 1}`"
@@ -1239,7 +1239,7 @@ export default Vue.extend({
                       <li>
                         <label
                           for="no review"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             id="no review"
@@ -1254,7 +1254,7 @@ export default Vue.extend({
                       <li>
                         <label
                           for="cat_has_review"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             id="cat_has_review"
@@ -1270,7 +1270,7 @@ export default Vue.extend({
                       >
                         <label
                           :for="`review_${index}`"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             :id="`review_${index}`"
@@ -1319,7 +1319,7 @@ export default Vue.extend({
                       >
                         <label
                           :for="`labeler_${key}`"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             :id="`labeler_${key}`"
@@ -1366,7 +1366,7 @@ export default Vue.extend({
                       >
                         <label
                           :for="`reviewer_${key}`"
-                          class="checkboxLabel"
+                          class="checkboxLabel options"
                         >
                           <input
                             :id="`reviewer_${key}`"
@@ -1814,7 +1814,7 @@ export default Vue.extend({
                 <li>
                   <label
                     for="className"
-                    class="checkboxLabel"
+                    class="checkboxLabel options"
                   >
                     <input
                       id="className"
@@ -1828,7 +1828,7 @@ export default Vue.extend({
                 <li>
                   <label
                     for="confidence"
-                    class="checkboxLabel"
+                    class="checkboxLabel options"
                   >
                     <input
                       id="confidence"
@@ -1842,7 +1842,7 @@ export default Vue.extend({
                 <li>
                   <label
                     for="certainty"
-                    class="checkboxLabel"
+                    class="checkboxLabel options"
                   >
                     <input
                       id="certainty"
@@ -1856,7 +1856,7 @@ export default Vue.extend({
                 <li>
                   <label
                     for="prediction"
-                    class="checkboxLabel"
+                    class="checkboxLabel options"
                   >
                     <input
                       id="prediction"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -2004,10 +2004,22 @@ export default Vue.extend({
       class="col-sm-9 chips-container"
     >
       <div id="superpixelChips">
+        <h3
+          v-if="Object.values(trimmedSuperpixels).length === 0"
+          :style="{'text-align': 'center'}"
+        >
+          No Results Found
+        </h3>
         <div
           v-for="[label, value] in Object.entries(trimmedSuperpixels)"
           :key="label"
         >
+          <h3
+            v-if="Object.values(value).length === 0"
+            :style="{'text-align': 'center'}"
+          >
+            No Results Found
+          </h3>
           <h4
             v-if="groupBy !== 0"
             :class="[groupBy >= 2 && 'group-header']"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -2137,6 +2137,7 @@ export default Vue.extend({
 
 .grouped {
   border: none !important;
+  margin: 0px 2px;
 }
 
 .ungrouped {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -152,7 +152,7 @@ export default Vue.extend({
                 this.scrollObserver.unobserve(this.observedSuperpixel);
             }
             const filteredContainsSelected = _.findWhere(data, this.selectedSuperpixel);
-            if (!filteredContainsSelected) {
+            if (!filteredContainsSelected && data.length) {
                 // If the selected superpixel has been filtered out fall back to the first available
                 this.selectedSuperpixel = Object.values(data)[0][0];
             }
@@ -651,7 +651,7 @@ export default Vue.extend({
                 if (!changedSuperpixel) {
                     this.totalSuperpixels = filtered.length;
                     this.filteredSortedGroupedSuperpixels = _.mapObject(data, (value) => this.sortSuperpixels(value));
-                } else {
+                } else if (data) {
                     const [group] = Object.keys(data);
                     const superpixels = this.filteredSortedGroupedSuperpixels;
                     let index = -1;
@@ -678,7 +678,7 @@ export default Vue.extend({
                     }
                     this.filteredSortedGroupedSuperpixels[group].splice(index, 0, changedSuperpixel);
                 }
-                if (!this.selectedSuperpixel) {
+                if (!this.selectedSuperpixel && this.filteredSortedGroupedSuperpixels.data) {
                     this.selectedSuperpixel = this.filteredSortedGroupedSuperpixels.data[0];
                 }
                 this.$nextTick(() => this.hideProgressBar());

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -612,33 +612,30 @@ export default Vue.extend({
             this.openMenu = this.openMenu === menu ? null : menu;
         },
         selectedComparisonText(selection) {
-            if (!selection || selection === 'prediction') {
-                return selection;
-            } else {
-                const [, userID] = selection.split('_');
-                let user;
-                if (store.currentUser === userID) {
-                    user = store.currentUser;
-                } else {
-                    const superpixel = _.find(this.superpixelsForReview, (superpixel) => {
-                        if (superpixel.meta) {
-                            return (
-                                (!!superpixel.meta.reviewer === userID) ||
-                              (!!superpixel.meta.labeler === userID)
-                            );
-                        }
-                        return false;
-                    });
-                    if (!superpixel) {
-                        return '';
+            if (!selection) return selection;
+
+            const [, userID] = selection.split('_');
+            if (!userID) return selection;
+
+            let user = store.currentUser;
+            if (!(store.currentUser === userID)) {
+                const superpixel = _.find(this.superpixelsForReview, (superpixel) => {
+                    if (superpixel.meta) {
+                        return (
+                            (!!superpixel.meta.reviewer === userID) ||
+                            (!!superpixel.meta.labeler === userID)
+                        );
                     }
-                    user = superpixel.meta.labeler;
-                    if (!!superpixel.meta.reviewer === userID) {
-                        user = superpixel.meta.reviewer;
-                    }
+                    return false;
+                });
+                if (!superpixel) return '';
+
+                user = superpixel.meta.labeler;
+                if (!!superpixel.meta.reviewer === userID) {
+                    user = superpixel.meta.reviewer;
                 }
-                return store.userNames[user];
             }
+            return store.userNames[user];
         },
         updateFilteredSortedGroupedSuperpixels(changedSuperpixel) {
             this.showProgressBar();
@@ -1431,6 +1428,40 @@ export default Vue.extend({
                         </label>
                       </div>
                     </li>
+                    <li>
+                      <div class="radio">
+                        <label
+                          for="labels_comparison_1"
+                          :class="['options', secondComparison === 'labels' && 'disabled-label']"
+                        >
+                          <input
+                            id="labels_comparison_1"
+                            v-model="firstComparison"
+                            type="radio"
+                            value="labels"
+                            class="hidden-radio"
+                          >
+                          Labels
+                        </label>
+                      </div>
+                    </li>
+                    <li>
+                      <div class="radio">
+                        <label
+                          for="reviews_comparison_1"
+                          :class="['options', secondComparison === 'reviews' && 'disabled-label']"
+                        >
+                          <input
+                            id="reviews_comparison_1"
+                            v-model="firstComparison"
+                            type="radio"
+                            value="review"
+                            class="hidden-radio"
+                          >
+                          Reviews
+                        </label>
+                      </div>
+                    </li>
                     <li
                       v-for="key in filterOptions.Labelers"
                       :key="`comp_labeler_${key}`"
@@ -1573,10 +1604,7 @@ export default Vue.extend({
                       </div>
                     </li>
                     <li>
-                      <div
-                        class="radio"
-                        :disabled="firstComparison === 'prediction'"
-                      >
+                      <div class="radio">
                         <label
                           for="prediction_comparison_2"
                           :class="['options', firstComparison === 'prediction' && 'disabled-label']"
@@ -1589,6 +1617,40 @@ export default Vue.extend({
                             class="hidden-radio"
                           >
                           Predictions
+                        </label>
+                      </div>
+                    </li>
+                    <li>
+                      <div class="radio">
+                        <label
+                          for="labels_comparison_2"
+                          :class="['options', firstComparison === 'labels' && 'disabled-label']"
+                        >
+                          <input
+                            id="labels_comparison_2"
+                            v-model="secondComparison"
+                            type="radio"
+                            value="labels"
+                            class="hidden-radio"
+                          >
+                          Labels
+                        </label>
+                      </div>
+                    </li>
+                    <li>
+                      <div class="radio">
+                        <label
+                          for="reviews_comparison_2"
+                          :class="['options', firstComparison === 'reviews' && 'disabled-label']"
+                        >
+                          <input
+                            id="reviews_comparison_2"
+                            v-model="secondComparison"
+                            type="radio"
+                            value="review"
+                            class="hidden-radio"
+                          >
+                          Reviews
                         </label>
                       </div>
                     </li>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -44,7 +44,8 @@ export default Vue.extend({
             cardDetails: [],
             firstComparison: null,
             secondComparison: null,
-            booleanOperator: null
+            booleanOperator: null,
+            filtersAllLabels: true
         };
     },
     computed: {
@@ -178,6 +179,17 @@ export default Vue.extend({
         sortAscending() {
             Object.values(this.filteredSortedGroupedSuperpixels)
                 .map((sortedList) => sortedList.reverse());
+        },
+        filtersAllLabels: {
+            handler() {
+                const labels = store.categories.slice(1).map((cat) => `label_${cat.label}`);
+                if (this.filtersAllLabels) {
+                    store.filterBy.push(...labels);
+                } else {
+                    store.filterBy = store.filterBy.filter((value) => !labels.includes(value));
+                }
+            },
+            immediate: true
         }
     },
     mounted() {
@@ -1080,21 +1092,49 @@ export default Vue.extend({
                       </span>
                     </div>
                     <ul :class="['dropdown-menu', openMenu === 'labels' ? 'visible-menu' : 'hidden']">
-                      <li
-                        v-for="(cat, index) in filterOptions.Labels"
-                        :key="`cat_${index}`"
-                      >
+                      <li>
                         <label
-                          :for="`cat_${index}`"
+                          for="cat_0"
                           class="checkboxLabel"
                         >
                           <input
-                            :id="`cat_${index}`"
+                            id="cat_0"
+                            v-model="filterBy"
+                            type="checkbox"
+                            value="label_default"
+                          >
+                          No Label
+                        </label>
+                      </li>
+                      <li><hr></li>
+                      <li>
+                        <label
+                          for="cat_has_label"
+                          class="checkboxLabel"
+                        >
+                          <input
+                            id="cat_has_label"
+                            v-model="filtersAllLabels"
+                            type="checkbox"
+                          >
+                          All Labels
+                        </label>
+                      </li>
+                      <li
+                        v-for="(cat, index) in filterOptions.Labels.slice(1)"
+                        :key="`cat_${index + 1}`"
+                      >
+                        <label
+                          :for="`cat_${index + 1}`"
+                          class="checkboxLabel"
+                        >
+                          <input
+                            :id="`cat_${index + 1}`"
                             v-model="filterBy"
                             type="checkbox"
                             :value="`label_${cat}`"
                           >
-                          {{ index === 0 ? 'No Label' : cat }}
+                          {{ cat }}
                         </label>
                       </li>
                     </ul>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -1435,7 +1435,7 @@ export default Vue.extend({
                       <div class="radio">
                         <label
                           :for="`comp_labeler_${key}_1`"
-                          :class="['options', (!!secondComparison && secondComparison.startsWith('label')) && 'disabled-label']"
+                          :class="['options', secondComparison === `label_${key}` && 'disabled-label']"
                         >
                           <input
                             :id="`comp_labeler_${key}_1`"
@@ -1455,7 +1455,7 @@ export default Vue.extend({
                       <div class="radio">
                         <label
                           :for="`comp_reviewer_${key}_1`"
-                          :class="['options', (!!secondComparison && secondComparison.startsWith('review')) && 'disabled-label']"
+                          :class="['options', secondComparison === `review_${key}` && 'disabled-label']"
                         >
                           <input
                             :id="`comp_reviewer_${key}_1`"
@@ -1544,6 +1544,7 @@ export default Vue.extend({
                     class="btn btn-block btn-default dropdown-toggle dropdown-button"
                     type="button"
                     data-toggle="dropdown"
+                    :disabled="!firstComparison || !booleanOperator"
                   >
                     <span class="overflow-text">
                       {{ selectedComparisonText(secondComparison) || (!!firstComparison && !!booleanOperator ? 'Any' : '(None)') }}
@@ -1552,10 +1553,7 @@ export default Vue.extend({
                   </button>
                   <ul class="dropdown-menu">
                     <li>
-                      <div
-                        class="radio"
-                        :disabled="firstComparison === 'prediction'"
-                      >
+                      <div class="radio">
                         <label for="any">
                           <input
                             id="any"
@@ -1595,7 +1593,7 @@ export default Vue.extend({
                       <div class="radio">
                         <label
                           :for="`comp_labeler_${key}_2`"
-                          :class="['options', (!!firstComparison && firstComparison.startsWith('label')) && 'disabled-label']"
+                          :class="['options', firstComparison === `label_${key}` && 'disabled-label']"
                         >
                           <input
                             :id="`comp_labeler_${key}_2`"
@@ -1615,7 +1613,7 @@ export default Vue.extend({
                       <div class="radio">
                         <label
                           :for="`comp_reviewer_${key}_2`"
-                          :class="['options', (!!firstComparison && firstComparison.startsWith('review')) && 'disabled-label']"
+                          :class="['options', firstComparison === `review_${key}` && 'disabled-label']"
                         >
                           <input
                             :id="`comp_reviewer_${key}_2`"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -593,7 +593,7 @@ export default Vue.extend({
                 this.scrollObserver.unobserve(this.observedSuperpixel);
             }
             this.observedSuperpixel = _.last(document.getElementsByClassName('h-superpixel-card'));
-            if (this.sliceValue === 1) {
+            if (this.sliceValue === 1 && this.observedSuperpixel) {
                 // Make an initial estimate of how many chips to show
                 const container = document.getElementById('chipsContainer');
                 const containerRect = container.getBoundingClientRect();

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -1399,7 +1399,10 @@ export default Vue.extend({
                   <ul class="dropdown-menu">
                     <li>
                       <div class="radio">
-                        <label for="no_selection_1">
+                        <label
+                          for="no_selection_1"
+                          class="options"
+                        >
                           <input
                             id="no_selection_1"
                             v-model="firstComparison"
@@ -1554,7 +1557,10 @@ export default Vue.extend({
                   <ul class="dropdown-menu">
                     <li>
                       <div class="radio">
-                        <label for="any">
+                        <label
+                          for="any"
+                          class="options"
+                        >
                           <input
                             id="any"
                             v-model="secondComparison"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -451,12 +451,17 @@ export default Vue.extend({
                 return store.categories[selectedCategory].label;
             });
         },
-        groupByLabelPredictionAgreement(data) {
+        groupByPredictionCategory(data) {
             return Object.groupBy(data, (superpixel) => {
-                const { selectedCategory, prediction } = superpixel;
-                const selection = superpixel.labelCategories[selectedCategory].label;
-                const predicted = superpixel.predictionCategories[prediction].label;
-                return selection === predicted ? 'Agree' : 'Disagree';
+                return superpixel.predictionCategories[superpixel.prediction].label;
+            });
+        },
+        groupByReviewCategory(data) {
+            return Object.groupBy(data, ({ reviewValue }) => {
+                if (!_.isNumber(reviewValue)) {
+                    return 'default';
+                }
+                return store.categories[reviewValue].label;
             });
         },
         groupSuperpixels(data) {
@@ -466,7 +471,9 @@ export default Vue.extend({
                 case 2:
                     return this.groupByLabelCategory(data);
                 case 3:
-                    return this.groupByLabelPredictionAgreement(data);
+                    return this.groupByPredictionCategory(data);
+                case 4:
+                    return this.groupByReviewCategory(data);
                 default:
                     return { data };
             }
@@ -1807,12 +1814,12 @@ export default Vue.extend({
         >
           <h4
             v-if="groupBy !== 0"
-            :class="[groupBy === 2 && 'group-header']"
+            :class="[groupBy >= 2 && 'group-header']"
             :style="[{'margin-left': '5px'}]"
           >
-            {{ label }} ({{ filteredSortedGroupedSuperpixels[label].length }})
+            {{ label === 'default' ? 'None' : label }} ({{ filteredSortedGroupedSuperpixels[label].length }})
             <i
-              v-if="groupBy === 2"
+              v-if="groupBy >= 2"
               class="icon-blank"
               :class="[groupBy === 2 && 'group-icon']"
               :style="{'background-color': catColorByLabel(label)}"
@@ -1825,11 +1832,11 @@ export default Vue.extend({
               :key="index"
               :class="[
                 'h-superpixel-card',
-                groupBy === 2 ? 'grouped' : 'ungrouped',
+                groupBy >= 2 ? 'grouped' : 'ungrouped',
                 superpixel === selectedSuperpixel && 'selected-superpixel',
                 cardDetails.length > 0 && 'h-superpixel-card-detailed'
               ]"
-              :style="[groupBy !== 2 && {'border-color': catColorByIndex(superpixel.selectedCategory)}]"
+              :style="[groupBy < 2 && {'border-color': catColorByIndex(superpixel.selectedCategory)}]"
             >
               <active-learning-review-card
                 :style="{'position': 'relative'}"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -372,11 +372,11 @@ export default Vue.extend({
                     if (key === 'prediction') {
                         values[idx] = superpixel.predictionCategories[superpixel.prediction];
                     } else if (key === 'label') {
-                        if (!this.secondComparison || (!!superpixel.meta && !!superpixel.meta.labeler === userID)) {
+                        if (!this.secondComparison || (!!superpixel.meta && superpixel.meta.labeler === userID)) {
                             values[idx] = superpixel.labelCategories[superpixel.selectedCategory];
                         }
                     } else if (key === 'review') {
-                        if (!this.secondComparison || (!!superpixel.meta && !!superpixel.meta.reviewer === userID)) {
+                        if (!this.secondComparison || (!!superpixel.meta && superpixel.meta.reviewer === userID)) {
                             values[idx] = superpixel.labelCategories[superpixel.reviewValue];
                         }
                     }
@@ -1295,11 +1295,11 @@ export default Vue.extend({
                     <li>
                       <div class="radio">
                         <label
-                          for="prediction_1"
+                          for="prediction_comparison_1"
                           :class="['options', secondComparison === 'prediction' && 'disabled-label']"
                         >
                           <input
-                            id="prediction_1"
+                            id="prediction_comparison_1"
                             v-model="firstComparison"
                             type="radio"
                             value="prediction"
@@ -1437,10 +1437,7 @@ export default Vue.extend({
                         class="radio"
                         :disabled="firstComparison === 'prediction'"
                       >
-                        <label
-                          for="any"
-                          :class="['options', firstComparison === 'prediction' && 'disabled-label']"
-                        >
+                        <label for="any">
                           <input
                             id="any"
                             v-model="secondComparison"
@@ -1458,11 +1455,11 @@ export default Vue.extend({
                         :disabled="firstComparison === 'prediction'"
                       >
                         <label
-                          for="prediction_2"
+                          for="prediction_comparison_2"
                           :class="['options', firstComparison === 'prediction' && 'disabled-label']"
                         >
                           <input
-                            id="prediction_2"
+                            id="prediction_comparison_2"
                             v-model="secondComparison"
                             type="radio"
                             value="prediction"

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -127,15 +127,15 @@ export default Vue.extend({
         userSelections() {
             return [
                 ...store.filterBy,
-                this.firstComparison,
-                this.secondComparison,
-                this.booleanOperator,
                 ...this.sortBy,
                 ...this.groupBy
             ];
         },
         changeLog() {
             return store.changeLog;
+        },
+        comparisonSelections() {
+            return [this.firstComparison, this.booleanOperator, this.secondComparison];
         }
     },
     watch: {
@@ -158,11 +158,12 @@ export default Vue.extend({
             }
             this.$nextTick(() => this.updateObserved());
         },
-        firstComparison() {
+        comparisonSelections(_newComps, oldComps) {
+            const [oldFirst, oldBoolean] = oldComps;
             this.showFlags = !!this.firstComparison && !!this.booleanOperator;
-        },
-        booleanOperator() {
-            this.showFlags = !!this.firstComparison && !!this.booleanOperator;
+            if (this.showFlags || (oldFirst && oldBoolean)) {
+                this.updateFilteredSortedGroupedSuperpixels();
+            }
         },
         userSelections() {
             this.updateFilteredSortedGroupedSuperpixels();
@@ -487,7 +488,7 @@ export default Vue.extend({
                 results = this.filterBySlideName(results, filterBy);
             }
             if (!!this.firstComparison && !!this.booleanOperator) {
-                results = this.filterByComparison(data);
+                results = this.filterByComparison(results);
             }
             filterBy = getFilters('labeler_');
             if (filterBy.length > 0) {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -634,8 +634,24 @@ export default Vue.extend({
         removeFilters(values) {
             store.filterBy = _.without(store.filterBy, ...values);
         },
+        confirmMenuFocus(event) {
+            const menu = document.getElementsByClassName('visible-menu')[0];
+            if (menu && !menu.contains(event.target)) {
+                this.toggleOpenMenu(this.openMenu);
+            }
+        },
         toggleOpenMenu(menu) {
-            this.openMenu = this.openMenu === menu ? null : menu;
+            if (this.openMenu === menu) {
+                // Menu was open; closing now
+                this.openMenu = null;
+                document.removeEventListener('click', this.confirmMenuFocus);
+            } else {
+                // Menu was closed; opening now
+                this.openMenu = menu;
+                this.$nextTick(() => {
+                    document.addEventListener('click', this.confirmMenuFocus);
+                });
+            }
         },
         selectedComparisonText(selection) {
             if (!selection) return selection;
@@ -647,10 +663,7 @@ export default Vue.extend({
             if (!(store.currentUser === userID)) {
                 const superpixel = _.find(this.superpixelsForReview, (superpixel) => {
                     if (superpixel.meta) {
-                        return (
-                            (!!superpixel.meta.reviewer === userID) ||
-                            (!!superpixel.meta.labeler === userID)
-                        );
+                        return superpixel.meta.reviewer === userID || superpixel.meta.labeler === userID;
                     }
                     return false;
                 });
@@ -1068,6 +1081,7 @@ export default Vue.extend({
                     <div
                       class="btn btn-default btn-block"
                       @click="toggleOpenMenu('slide')"
+                      @click.stop
                     >
                       <span class="multiselect-dropdown-label">
                         Slide Image
@@ -1114,6 +1128,7 @@ export default Vue.extend({
                     <div
                       class="btn btn-default btn-block"
                       @click="toggleOpenMenu('prediction')"
+                      @click.stop
                     >
                       <span class="multiselect-dropdown-label">
                         Predictions
@@ -1162,6 +1177,7 @@ export default Vue.extend({
                     <div
                       class="btn btn-default btn-block"
                       @click="toggleOpenMenu('labels')"
+                      @click.stop
                     >
                       <span class="multiselect-dropdown-label">
                         Labels
@@ -1237,6 +1253,7 @@ export default Vue.extend({
                     <div
                       class="btn btn-default btn-block"
                       @click="toggleOpenMenu('reviews')"
+                      @click.stop
                     >
                       <span class="multiselect-dropdown-label">
                         Reviews
@@ -1314,6 +1331,7 @@ export default Vue.extend({
                     <div
                       class="btn btn-default btn-block"
                       @click="toggleOpenMenu('labeler')"
+                      @click.stop
                     >
                       <span class="multiselect-dropdown-label">
                         Labeled By
@@ -1361,6 +1379,7 @@ export default Vue.extend({
                       class="btn btn-default btn-block"
                       :disabled="!filterOptions.Reviewers.length"
                       @click="toggleOpenMenu('reviewer')"
+                      @click.stop
                     >
                       <span class="multiselect-dropdown-label">
                         Reviewed By
@@ -1812,6 +1831,7 @@ export default Vue.extend({
               <div
                 class="btn btn-default btn-block"
                 @click="toggleOpenMenu('data')"
+                @click.stop
               >
                 <span class="multiselect-dropdown-label">
                   Superpixel Data

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -45,7 +45,8 @@ export default Vue.extend({
             firstComparison: null,
             secondComparison: null,
             booleanOperator: null,
-            filtersAllLabels: true
+            filtersAllLabels: true,
+            filtersAllReviews: false
         };
     },
     computed: {
@@ -190,6 +191,14 @@ export default Vue.extend({
                 }
             },
             immediate: true
+        },
+        filtersAllReviews() {
+            const reviews = store.categories.map((cat) => `review_${cat.label}`);
+            if (this.filtersAllReviews) {
+                store.filterBy.push(...reviews);
+            } else {
+                store.filterBy = store.filterBy.filter((value) => !reviews.includes(value));
+            }
         }
     },
     mounted() {
@@ -1109,11 +1118,11 @@ export default Vue.extend({
                       <li><hr></li>
                       <li>
                         <label
-                          for="cat_has_label"
+                          for="cat_has_review"
                           class="checkboxLabel"
                         >
                           <input
-                            id="cat_has_label"
+                            id="cat_has_review"
                             v-model="filtersAllLabels"
                             type="checkbox"
                           >
@@ -1177,7 +1186,21 @@ export default Vue.extend({
                             type="checkbox"
                             value="no review"
                           >
-                          not reviewed
+                          No Review
+                        </label>
+                      </li>
+                      <li><hr></li>
+                      <li>
+                        <label
+                          for="cat_has_label"
+                          class="checkboxLabel"
+                        >
+                          <input
+                            id="cat_has_label"
+                            v-model="filtersAllReviews"
+                            type="checkbox"
+                          >
+                          All Reviews
                         </label>
                       </li>
                       <li
@@ -1194,7 +1217,7 @@ export default Vue.extend({
                             type="checkbox"
                             :value="`review_${cat}`"
                           >
-                          {{ index === 0 ? 'Unlabeled' : cat }}
+                          {{ index === 0 ? 'unlabeled' : cat }}
                         </label>
                       </li>
                     </ul>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -6,7 +6,7 @@ import ActiveLearningReviewCard from './ActiveLearningReviewCard.vue';
 import ActiveLearningLabeling from '../ActiveLearningLabeling.vue';
 import { store } from '../store.js';
 import { groupByOptions, sortByOptions } from '../constants';
-import { updateMetadata, rgbStringToArray } from '../utils.js';
+import { updateMetadata, rgbStringToArray, isValidNumber } from '../utils.js';
 
 export default Vue.extend({
     components: {
@@ -393,13 +393,13 @@ export default Vue.extend({
             if (filterBy.length > -1) {
                 reviewResults = reviewResults.concat(data.filter((superpixel) => {
                     const { reviewValue, labelCategories } = superpixel;
-                    const label = _.isNumber(reviewValue) ? labelCategories[reviewValue].label : '';
+                    const label = isValidNumber(reviewValue) ? labelCategories[reviewValue].label : '';
                     return filterBy.indexOf(label) > -1;
                 }));
             }
             if (store.filterBy.indexOf('no review') > -1) {
                 reviewResults = reviewResults.concat(data.filter((superpixel) => {
-                    return !superpixel.meta || !_.isNumber(superpixel.meta.reviewValue);
+                    return !isValidNumber(superpixel.reviewValue);
                 }));
             }
             return reviewResults;
@@ -523,7 +523,7 @@ export default Vue.extend({
         },
         groupByReviewCategory(data) {
             return Object.groupBy(data, ({ reviewValue }) => {
-                if (!_.isNumber(reviewValue)) {
+                if (!isValidNumber(reviewValue)) {
                     return 'default';
                 }
                 return store.categories[reviewValue].label;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -131,8 +131,8 @@ export default Vue.extend({
                 ...this.groupBy
             ];
         },
-        changeLog() {
-            return store.changeLog;
+        reviewChangeLog() {
+            return store.reviewChangeLog;
         },
         comparisonSelections() {
             return [this.firstComparison, this.booleanOperator, this.secondComparison];
@@ -168,13 +168,17 @@ export default Vue.extend({
         userSelections() {
             this.updateFilteredSortedGroupedSuperpixels();
         },
-        changeLog: {
+        reviewChangeLog: {
             handler() {
-                if (!store.changeLog.length) {
+                if (!store.reviewChangeLog.length) {
                     return;
                 }
-                const changedSuperpixel = this.changeLog.pop();
+                const changedSuperpixel = this.reviewChangeLog.pop();
                 this.updateFilteredSortedGroupedSuperpixels(changedSuperpixel);
+                // All changes in this change log are label changes.
+                // Make sure the metadata is kept in sync.
+                updateMetadata(changedSuperpixel, changedSuperpixel.selectedCategory, false);
+                store.backboneParent.updateAnnotationMetadata(changedSuperpixel.imageId);
             },
             deep: true
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -596,10 +596,14 @@ export default Vue.extend({
                 event.stopImmediatePropagation();
             }
         },
-        applyBulkReview(newValue) {
+        applyBulkReview(selectedValue) {
+            const imageIds = new Set();
             this.selectedReviewSuperpixels.forEach((superpixel) => {
+                const newValue = selectedValue === -1 ? superpixel.selectedCategory : selectedValue;
                 updateMetadata(superpixel, newValue, true);
+                imageIds.add(superpixel.imageId);
             });
+            store.backboneParent.saveAnnotationMetadata(Array.from(imageIds));
             this.selectedReviewSuperpixels = [];
             this.selectingSuperpixels = false;
         },
@@ -1944,7 +1948,7 @@ export default Vue.extend({
               type="button"
               class="btn btn-success btn-group-two"
               :disabled="selectedReviewSuperpixels.length < 1"
-              @click="() => applyBulkReview(0)"
+              @click="() => applyBulkReview(-1)"
             >
               Approve
             </button>

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -503,7 +503,7 @@ export default Vue.extend({
             }
             filterBy = getFilters('prediction_');
             if (filterBy.length > 0) {
-                results = this.filterByPredictionLabel(data, filterBy);
+                results = this.filterByPredictionLabel(results, filterBy);
             }
             const slideNames = _.pluck(this.imageItemsById, 'name');
             filterBy = store.filterBy.filter((value) => slideNames.includes(value));
@@ -515,11 +515,11 @@ export default Vue.extend({
             }
             filterBy = getFilters('labeler_');
             if (filterBy.length > 0) {
-                results = this.filterByLabeler(data, filterBy);
+                results = this.filterByLabeler(results, filterBy);
             }
             filterBy = getFilters('reviewer_');
             if (filterBy.length > 0) {
-                results = this.filterByReviewer(data, filterBy);
+                results = this.filterByReviewer(results, filterBy);
             }
             return results;
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -280,7 +280,6 @@ export default Vue.extend({
             menuObserver.observe(element);
         });
 
-        this.selectedSuperpixel = this.filteredSortedGroupedSuperpixels.data[0];
         this.$nextTick(() => {
             const resizeHandle = document.querySelector('.resize-handle');
             resizeHandle.removeEventListener('mousedown', () => { this.isResizing = true; });
@@ -674,6 +673,9 @@ export default Vue.extend({
                             break;
                     }
                     this.filteredSortedGroupedSuperpixels[group].splice(index, 0, changedSuperpixel);
+                }
+                if (!this.selectedSuperpixel) {
+                    this.selectedSuperpixel = this.filteredSortedGroupedSuperpixels.data[0];
                 }
                 this.$nextTick(() => this.hideProgressBar());
             }, 0);

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -564,7 +564,11 @@ export default Vue.extend({
             }
         },
         catColorByLabel(label) {
-            return _.findWhere(store.categories, { label }).fillColor;
+            const cat = _.findWhere(store.categories, { label });
+            if (cat) {
+                return cat.fillColor;
+            }
+            return 'rgb(0, 0, 0)';
         },
         catColorByIndex(index) {
             const color = store.categories[index].fillColor;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -7,7 +7,7 @@ import { ViewerWidget } from '@girder/large_image_annotation/views';
 
 import { activeLearningSteps, boundaryColor, viewMode } from './constants.js';
 import { store, updatePixelmapLayerStyle } from './store.js';
-import { getFillColor } from './utils.js';
+import { getFillColor, updateMetadata } from './utils.js';
 
 export default Vue.extend({
     props: ['availableImages'],
@@ -128,6 +128,7 @@ export default Vue.extend({
                 this.drawPixelmapAnnotation();
                 store.backboneParent.saveAnnotations([superpixel.imageId], false);
                 store.reviewChangeLog.push(superpixel);
+                updateMetadata(superpixel, superpixel.selectedCategory, false);
             },
             deep: true
         },
@@ -466,6 +467,7 @@ export default Vue.extend({
             this.updateRunningLabelCounts(boundaries, index, newLabel, previousLabel);
             // Make sure the review mode stays in sync with these changes
             store.reviewChangeLog.push(superpixel);
+            updateMetadata(superpixel, superpixel.selectedCategory, false);
         },
         saveNewPixelmapData(boundaries, data) {
             const annotation = store.annotationsByImageId[store.currentImageId];

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -126,9 +126,9 @@ export default Vue.extend({
                 // main review change log so that the review mode is updated as well.
                 const superpixel = store.labelingChangeLog.pop();
                 this.drawPixelmapAnnotation();
+                updateMetadata(superpixel, superpixel.selectedCategory, false);
                 store.backboneParent.saveAnnotations([superpixel.imageId], false);
                 store.reviewChangeLog.push(superpixel);
-                updateMetadata(superpixel, superpixel.selectedCategory, false);
             },
             deep: true
         },
@@ -458,16 +458,15 @@ export default Vue.extend({
                 // superpixels. Build our own.
                 superpixel = {
                     imageId: store.currentImageId,
-                    selectedCategory: newLabel,
                     index: boundaries ? index / 2 : index
                 };
             }
-
+            superpixel.selectedCategory = newLabel;
+            updateMetadata(superpixel, newLabel, false);
             this.saveNewPixelmapData(boundaries, _.clone(data));
             this.updateRunningLabelCounts(boundaries, index, newLabel, previousLabel);
             // Make sure the review mode stays in sync with these changes
             store.reviewChangeLog.push(superpixel);
-            updateMetadata(superpixel, superpixel.selectedCategory, false);
         },
         saveNewPixelmapData(boundaries, data) {
             const annotation = store.annotationsByImageId[store.currentImageId];

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/constants.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/constants.js
@@ -52,7 +52,8 @@ export const groupByOptions = {
     0: '(None)',
     1: 'Slide',
     2: 'Label',
-    3: 'Agree/Disagree'
+    3: 'Prediction',
+    4: 'Review'
 };
 
 export const sortByOptions = {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/constants.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/constants.js
@@ -60,7 +60,8 @@ export const sortByOptions = {
     0: '(None)',
     1: 'Slide',
     2: 'Label',
-    3: 'Agree/Disagree',
-    4: 'Confidence',
-    5: 'Certainty'
+    3: 'Prediction',
+    4: 'Review',
+    5: 'Confidence',
+    6: 'Certainty'
 };

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -11,8 +11,8 @@ const store = Vue.observable({
      *********/
     apiRoot: '',
     superpixelsToDisplay: [],
-    changeLog: [],
-    guidedChangeLog: [],
+    reviewChangeLog: [],
+    labelingChangeLog: [],
     annotationsByImageId: {},
     backboneParent: null,
     categories: [],

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -46,6 +46,7 @@ export const updateMetadata = (superpixel, newCategory, isReview) => {
     meta[superpixel.index][`${key}Date`] = new Date().toDateString();
     meta[superpixel.index][`${key}Value`] = newCategory;
     meta[superpixel.index][`${key}Epoch`] = store.epoch;
+    superpixel.meta = meta[superpixel.index];
 
     if (isReview) {
         superpixel.reviewValue = newCategory;

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -39,21 +39,24 @@ export const rgbStringToArray = (rgbStr) => {
  * @param {boolean} isReview Whether or not this is a review. Will update the label if not a review.
 */
 export const updateMetadata = (superpixel, newCategory, isReview) => {
-    const labels = store.annotationsByImageId[superpixel.imageId].labels;
-    const meta = labels.get('annotation').attributes.metadata;
+    const annotation = store.annotationsByImageId[superpixel.imageId];
+    const attributes = annotation.labels.get('annotation').attributes;
+    // Guarantee that the metadata object exists
+    const meta = attributes.metadata || (attributes.metadata = {});
     // If no new value is provided user selection is correct
     const key = isReview ? 'review' : 'label';
+    // Guarantee that there is an entry for this superpixel in the metadata
     superpixel.index in meta || (meta[superpixel.index] = {});
     meta[superpixel.index][`${key}er`] = store.currentUser;
     meta[superpixel.index][`${key}Date`] = new Date().toDateString();
     meta[superpixel.index][`${key}Value`] = newCategory;
     meta[superpixel.index][`${key}Epoch`] = store.epoch;
+    // Keep the superpixel object in sync with the metadata
     superpixel.meta = meta[superpixel.index];
 
     if (isReview) {
         superpixel.reviewValue = newCategory;
     }
-
     store.backboneParent.updateAnnotationMetadata(superpixel.imageId);
 };
 

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -1,3 +1,5 @@
+import _ from 'underscore';
+
 import { schemeTableau10 } from './constants';
 import { store } from './store';
 
@@ -114,4 +116,14 @@ export const debounce = (fn, debounceByArguments = false) => {
             queuedRequests.set(stringArgs);
         }
     };
+};
+
+/**
+ * Simple util function for determining if a value is a valid number
+ *
+ * @param {*} value Value to check
+ * @returns {boolean} Whether or not value is a valid number
+ */
+export const isValidNumber = (value) => {
+    return _.isNumber(value) && !_.isNaN(value);
 };

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -53,6 +53,8 @@ export const updateMetadata = (superpixel, newCategory, isReview) => {
     if (isReview) {
         superpixel.reviewValue = newCategory;
     }
+
+    store.backboneParent.updateAnnotationMetadata(superpixel.imageId);
 };
 
 /**

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/utils.js
@@ -57,7 +57,6 @@ export const updateMetadata = (superpixel, newCategory, isReview) => {
     if (isReview) {
         superpixel.reviewValue = newCategory;
     }
-    store.backboneParent.updateAnnotationMetadata(superpixel.imageId);
 };
 
 /**


### PR DESCRIPTION
- Fix review mode toggle sort order
- Fix some bugs with the comparison filters
    - Fix comparison operator to ensure we're comparing user ids
    - Do not disable the "any" option for second comparison choice
    - Fix clashing component ids
- Update the `groupBy` options
    - Adds the option to group by prediction or by review
    - Removes the `agree/disagree` grouping option as it's too ambiguous
- Update the `sortBy` options
    - Add the options to sort by predictions or reviews
    - Remove the option to sort by `agree/disagree` because of ambiguity
- Add simple option to filter by labeled superpixels
- Add an "All Labels" option to the labels filter menu. Selecting the "All Labels" option selects all labels. De-selecting removes all label filters. Labels can still be selected/removed individually. The "no label" filter remains its own option.
- Update the `reviews` filter menu to better match the `labels` filter menu. This adds "All Reviews" to the reviews filter menu to mirror the setup of the labels filter menu.