### PR TITLE
Improve filter/group/sort

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -115,7 +115,7 @@ export default Vue.extend({
             store.categoriesAndIndices = [...store.categoriesAndIndices];
             updateMetadata(this.superpixelDecision, newValue, false);
             store.backboneParent.updateAnnotationMetadata(store.currentImageId);
-            store.changeLog.push(this.superpixelDecision);
+            store.guidedChangeLog.push(this.superpixelDecision);
         },
         lastCategorySelected(categoryNumber) {
             if (!this.isSelected || typeof categoryNumber !== 'number') {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -131,6 +131,9 @@ export default Vue.extend({
                 ...this.sortBy,
                 ...this.groupBy
             ];
+        },
+        changeLog() {
+            return store.changeLog;
         }
     },
     watch: {
@@ -161,6 +164,16 @@ export default Vue.extend({
         },
         userSelections() {
             this.updateFilteredSortedGroupedSuperpixels();
+        },
+        changeLog: {
+            handler() {
+                if (!store.changeLog.length) {
+                    return;
+                }
+                const changedSuperpixel = this.changeLog.pop();
+                this.updateFilteredSortedGroupedSuperpixels([changedSuperpixel]);
+            },
+            deep: true
         }
     },
     mounted() {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -236,7 +236,7 @@ export default Vue.extend({
         this.stopWatcher = this.$watch(
             'superpixelsForReview',
             () => this.updateFilteredSortedGroupedSuperpixels(),
-            { deep: true, immediate: true }
+            { deep: true }
         );
     },
     deactivated() {

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningReview/ActiveLearningReviewContainer.vue
@@ -171,7 +171,7 @@ export default Vue.extend({
                     return;
                 }
                 const changedSuperpixel = this.changeLog.pop();
-                this.updateFilteredSortedGroupedSuperpixels([changedSuperpixel]);
+                this.updateFilteredSortedGroupedSuperpixels(changedSuperpixel);
             },
             deep: true
         }
@@ -432,7 +432,6 @@ export default Vue.extend({
             if (filterBy.length > 0) {
                 results = this.filterByReviewer(data, filterBy);
             }
-            this.totalSuperpixels = results.length;
             return results;
         },
         /**********************************************************************
@@ -565,15 +564,44 @@ export default Vue.extend({
                 return store.userNames[user];
             }
         },
-        updateFilteredSortedGroupedSuperpixels() {
+        updateFilteredSortedGroupedSuperpixels(changedSuperpixel) {
             this.showProgressBar();
+            const superpixelsForReview = !changedSuperpixel ? this.superpixelsForReview : [changedSuperpixel];
             setTimeout(() => {
                 // Make sure the DOM has been updated to display the
                 // progress bar before begining the process
-                let data = this.filterSuperpixels(this.superpixelsForReview);
-                data = this.groupSuperpixels(data);
-                this.filteredSortedGroupedSuperpixels = _.mapObject(
-                    data, (value) => this.sortSuperpixels(value));
+                const filtered = this.filterSuperpixels(superpixelsForReview);
+                const data = this.groupSuperpixels(filtered);
+                if (!changedSuperpixel) {
+                    this.totalSuperpixels = filtered.length;
+                    this.filteredSortedGroupedSuperpixels = _.mapObject(data, (value) => this.sortSuperpixels(value));
+                } else {
+                    const [group] = Object.keys(data);
+                    const superpixels = this.filteredSortedGroupedSuperpixels;
+                    let index = -1;
+                    switch (this.sortBy) {
+                        case 1:
+                            index = _.sortedIndex(superpixels, (superpixel) => { return this.imageItemsById[superpixel.imageId].name; });
+                            break;
+                        case 2:
+                            index = _.sortedIndex(superpixels, 'selectedCategory');
+                            break;
+                        case 3:
+                            index = _.sortedIndex(superpixels, (superpixel) => {
+                                const selected = superpixel.labelCategories[superpixel.selectedCategory];
+                                const predicted = superpixel.predictionCategories[superpixel.prediction];
+                                return selected.label === predicted.label;
+                            });
+                            break;
+                        case 4:
+                            index = _.sortedIndex(superpixels, 'confidence');
+                            break;
+                        case 5:
+                            index = _.sortedIndex(superpixels, 'certainty');
+                            break;
+                    }
+                    this.filteredSortedGroupedSuperpixels[group].splice(index, 0, changedSuperpixel);
+                }
                 this.$nextTick(() => this.hideProgressBar());
             }, 0);
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSlideViewer.vue
@@ -54,7 +54,7 @@ export default Vue.extend({
             return store.selectedIndex;
         },
         changeLog() {
-            return store.changeLog;
+            return store.guidedChangeLog;
         },
         superpixelsToDisplay() {
             return store.superpixelsToDisplay;
@@ -118,12 +118,13 @@ export default Vue.extend({
         },
         changeLog: {
             handler() {
-                if (!store.changeLog.length) {
+                if (!store.guidedChangeLog.length) {
                     return;
                 }
-                const superpixel = this.changeLog.pop();
+                const superpixel = store.guidedChangeLog.pop();
                 this.drawPixelmapAnnotation();
                 store.backboneParent.saveAnnotations([superpixel.imageId], false);
+                store.changeLog.push(this.superpixelDecision);
             },
             deep: true
         },
@@ -462,6 +463,7 @@ export default Vue.extend({
 
             this.saveNewPixelmapData(boundaries, _.clone(data));
             this.updateRunningLabelCounts(boundaries, index, newLabel, previousLabel);
+            store.changeLog.push(superpixel);
         },
         saveNewPixelmapData(boundaries, data) {
             const annotation = store.annotationsByImageId[store.currentImageId];

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -12,6 +12,7 @@ const store = Vue.observable({
     apiRoot: '',
     superpixelsToDisplay: [],
     changeLog: [],
+    guidedChangeLog: [],
     annotationsByImageId: {},
     backboneParent: null,
     categories: [],


### PR DESCRIPTION
There are now two options when the list of review superpixels should be updated:
1. In `Labeling` or `Guided` mode changed superpixels are handled one at a time and the list is updated in-place.
2. In review mode the full list is updated when filters, grouping, or sort are changed.