### PR TITLE
Filmstrip scroll

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -91,6 +91,7 @@ export default {
             // update page
             store.page = Math.floor(currentIndex / store.pageSize);
             store.maxPage = Math.ceil((store.sortedSuperpixelIndices.length) / store.pageSize) - 1;
+            this.maxPage = store.maxPage;
             // update selected index
             store.selectedIndex = currentIndex - (store.pageSize * store.page);
             updateSelectedPage();

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -90,7 +90,7 @@ export default {
             store.pageSize = Math.floor(width / (cardWidth + padding));
             // update page
             store.page = Math.floor(currentIndex / store.pageSize);
-            store.maxPage = Math.ceil(store.sortedSuperpixelIndices.length / store.pageSize);
+            store.maxPage = Math.ceil((store.sortedSuperpixelIndices.length) / store.pageSize) - 1;
             // update selected index
             store.selectedIndex = currentIndex - (store.pageSize * store.page);
             updateSelectedPage();

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -11,11 +11,6 @@ export default {
         ActiveLearningFilmStripCard,
         ActiveLearningStats
     },
-    data() {
-        return {
-            maxPage: 500
-        };
-    },
     computed: {
         selectedIndex() {
             return store.selectedIndex;
@@ -32,6 +27,9 @@ export default {
                 return store.backboneParent.imageItemsById[id].name;
             }
             return '';
+        },
+        maxPage() {
+            return store.maxPage;
         }
     },
     watch: {
@@ -91,7 +89,6 @@ export default {
             // update page
             store.page = Math.floor(currentIndex / store.pageSize);
             store.maxPage = Math.ceil((store.sortedSuperpixelIndices.length) / store.pageSize) - 1;
-            this.maxPage = store.maxPage;
             // update selected index
             store.selectedIndex = currentIndex - (store.pageSize * store.page);
             updateSelectedPage();

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/store.js
@@ -86,7 +86,7 @@ const updateSelectedPage = () => {
     const endIndex = Math.min(startIndex + store.pageSize, store.sortedSuperpixelIndices.length);
     store.superpixelsToDisplay = store.sortedSuperpixelIndices.slice(startIndex, endIndex);
     store.currentImageId = store.superpixelsToDisplay[store.selectedIndex].imageId;
-    store.maxPage = store.sortedSuperpixelIndices.length / store.pageSize;
+    store.maxPage = Math.ceil(store.sortedSuperpixelIndices.length / store.pageSize) - 1;
 };
 
 /**


### PR DESCRIPTION
Hi,

In the AL filmstrip for labelling, the code for whether or not to disable scrolling to the next page is [here](https://github.com/DigitalSlideArchive/wsi-superpixel-guided-labeling/blob/master/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue#L133)

It seems you can scroll the filmstrip for past the end. The problem seems to be
 1) that `maxPage` has an OBO since the pagecount is 1-based instead of 0-based
 2) that `maxPage` is calculated/updated in the store, but the Vue component's `maxPage` is in an object separate from the store.

This PR has one commit for each item.
Not sure if my code change for `this.maxPage = store.maxPage;` is a clean approach, but at least a start/suggestion 😅 