### PR TITLE
Guided mode bugs

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStrip.vue
@@ -64,10 +64,19 @@ export default {
         },
         updateAll(usePrediction) {
             _.forEach(store.superpixelsToDisplay, (superpixel) => {
-                // Account for missing "default" category in predictions
-                const value = usePrediction ? superpixel.prediction + 1 : 0;
-                superpixel.selectedCategory = value;
-                updateMetadata(superpixel, value, false);
+                let categoryIndex = 0;
+                if (usePrediction) {
+                    // Try to match prediction category to label category
+                    const prediction = superpixel.predictionCategories[superpixel.prediction];
+                    const predictionCategory = prediction.label;
+                    categoryIndex = superpixel.labelCategories.findIndex((cat) => {
+                        return cat.label === predictionCategory;
+                    });
+                }
+                // Default to "no label" if no match found
+                categoryIndex = categoryIndex === -1 ? 0 : categoryIndex;
+                superpixel.selectedCategory = categoryIndex;
+                updateMetadata(superpixel, categoryIndex, false);
                 store.labelingChangeLog.push(superpixel);
             });
         },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import _ from 'underscore';
 
 import { store, nextCard } from '../store';
-import { updateMetadata } from '../utils';
+import { isValidNumber, updateMetadata } from '../utils';
 
 export default Vue.extend({
     props: ['index'],
@@ -117,19 +117,25 @@ export default Vue.extend({
             store.labelingChangeLog.push(this.superpixelDecision);
         },
         lastCategorySelected(categoryNumber) {
-            if (!this.isSelected || typeof categoryNumber !== 'number') {
+            if (!this.isSelected || !isValidNumber(categoryNumber)) {
                 return;
             }
-            if (categoryNumber <= this.superpixelDecision.predictionCategories.length) {
-                // Be extra careful to select the correct category
-                const newCategory = store.categories[categoryNumber];
-                const newCategoryIndex = this.categoryIndex(newCategory.label);
-                this.superpixelDecision.selectedCategory = newCategoryIndex;
-                this.$nextTick(() => {
-                    store.lastCategorySelected = null;
-                    nextCard();
-                });
+
+            if (
+                categoryNumber === 0 ||
+                categoryNumber >= this.superpixelDecision.labelCategories.length
+            ) {
+                // Be careful to select a valid category
+                return;
             }
+
+            const newCategory = store.categories[categoryNumber];
+            const newCategoryIndex = this.categoryIndex(newCategory.label);
+            this.superpixelDecision.selectedCategory = newCategoryIndex;
+            this.$nextTick(() => {
+                store.lastCategorySelected = null;
+                nextCard();
+            });
             store.lastCategorySelected = null; // reset state
         }
     },

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearning/ActiveLearningFilmStripCard.vue
@@ -51,7 +51,7 @@ export default Vue.extend({
             return `Certainty ${this.superpixelDecision.certainty.toFixed(5)}`;
         },
         validCategories() {
-            const categories = this.superpixelDecision.labelCategories;
+            const categories = store.categories;
             return _.filter(categories, (c) => !['default'].includes(c.label));
         },
         wsiRegionUrl() {


### PR DESCRIPTION
This branch fixes some issues in guided mode:
- If there were 5 categories and only 3 had labels there may only be 3 prediction categories. The old logic would prevent the hotkeys for categories 4 and 5 from working.
- The list of category options was not dynamically updated, meaning that if a category was added, removed, or renamed these changes would not be reflected until the page was refreshed.
- The "agree to all" logic made the assumption that the prediction categories would always be identical to the label categories, just offset by 1 (no default/unlabeled option for predictions). This is not guaranteed. This issue became apparent when category 1, 2, and 5 had labels but 3 and 4 had none - the predictions categories only had 3 items so simply offsetting the index by one selected the wrong label.