### PR TITLE
ENH: Add support for (foundation model) vector-shaped features

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningGlobalContainer.vue
@@ -29,6 +29,7 @@ export default Vue.extend({
         'imageNamesById',
         'annotationsByImageId',
         'certaintyMetrics',
+        'featureShapes',
         'apiRoot',
         'currentAverageCertainty',
         'availableImages',
@@ -140,6 +141,7 @@ export default Vue.extend({
       v-if="activeLearningStep === activeLearningSteps.SuperpixelSegmentation"
       :backbone-parent="backboneParent"
       :certainty-metrics="certaintyMetrics"
+      :feature-shapes="featureShapes"
     />
     <div v-if="storeReady && activeLearningStep > activeLearningSteps.SuperpixelSegmentation">
       <!-- Image Viewer -->

--- a/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
+++ b/wsi_superpixel_guided_labeling/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
@@ -2,12 +2,13 @@
 import Vue from 'vue';
 
 export default Vue.extend({
-    props: ['backboneParent', 'certaintyMetrics'],
+    props: ['backboneParent', 'certaintyMetrics', 'featureShapes'],
     data() {
         return {
             radius: 100,
             magnification: 5,
-            certaintyChoice: ''
+            certaintyChoice: '',
+            featureChoice: ''
         };
     },
     computed: {
@@ -17,13 +18,15 @@ export default Vue.extend({
     },
     mounted() {
         this.certaintyChoice = this.certaintyMetrics[0];
+        this.featureChoice = this.featureShapes[0];
     },
     methods: {
         generateInitialSuperpixels() {
             this.backboneParent.generateInitialSuperpixels(
                 this.radius,
                 this.magnification,
-                this.certaintyChoice
+                this.certaintyChoice,
+                this.featureChoice
             );
         }
     }
@@ -67,6 +70,24 @@ export default Vue.extend({
       >
         <option
           v-for="option in certaintyMetrics"
+          :key="option"
+          :value="option"
+        >
+          {{ option }}
+        </option>
+      </select>
+    </div>
+    <div class="form-group">
+      <label for="feature-shape">Feature Shape</label>
+      <div class="form-group-description">
+        Feature is superpixel image data or foundation model vector
+      </div>
+      <select
+        id="feature-shape"
+        v-model="featureChoice"
+      >
+        <option
+          v-for="option in featureShapes"
           :key="option"
           :value="option"
         >


### PR DESCRIPTION
Add an optional parameter `--feature`, with values `image` and `vector` to the interface with `SuperpixelClassification`, to tell `SuperpixelClassification` that it should create features as either images (the only implementation that was available until now) or vectors (using `MahmoodLab/UNI`).

When `SuperpixelClassification` is instead being invoked to train or predict, this parameter controls the shape of the model input and the model itself; the model for a `vector` is a simple "linear probing", whereas the model for an `image` continues to be a more complex, multi-layer model.

Also adjust an interface in HistomicsUI, so that when a user first loads an image and selects options for the superpixel construction, certainty metric, etc. they also specify the `--feature` value, which defaults to `image`.