### PR TITLE
Grab certainty and feature choices at the same time

### DIFF
--- a/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
+++ b/wsi_superpixel_guided_labeling/web_client/views/body/ActiveLearningView.js
@@ -568,8 +568,7 @@ const ActiveLearningView = View.extend({
             if (!jobInfo) {
                 throw new Error('Unable to find specified superpixel classification image.');
             }
-            this.getJobCertaintyChoices(jobInfo.xmlspec);
-            return this.getJobFeatureChoices(jobInfo.xmlspec);
+            return this.getJobCertaintyAndFeatureChoices(jobInfo.xmlspec);
         });
     },
 
@@ -607,10 +606,10 @@ const ActiveLearningView = View.extend({
     },
 
     /**
-     * Extract the certainty options from the superpixel predictions job.
+     * Extract the certainty and feature options from the superpixel predictions job.
      * @param {string} xmlUrl
      */
-    getJobCertaintyChoices(xmlUrl) {
+    getJobCertaintyAndFeatureChoices(xmlUrl) {
         restRequest({
             url: xmlUrl
         }).then((xmlSpec) => {
@@ -622,20 +621,6 @@ const ActiveLearningView = View.extend({
                 flattenedSpec.parameters.certainty.values.length
             );
             this.certaintyMetrics = hasCertaintyMetrics ? flattenedSpec.parameters.certainty.values : null;
-            return this.vueComponentChanged();
-        });
-    },
-
-    /**
-     * Extract the feature options from the superpixel predictions job.
-     * @param {string} xmlUrl
-     */
-    getJobFeatureChoices(xmlUrl) {
-        restRequest({
-            url: xmlUrl
-        }).then((xmlSpec) => {
-            const gui = parse(xmlSpec);
-            const flattenedSpec = this.flattenParse(gui);
             const hasFeatureShapes = (
                 flattenedSpec.parameters.feature &&
                 flattenedSpec.parameters.feature.values &&


### PR DESCRIPTION
This PR addresses a bug that we were seeing where:
- the initial labeling step would not automatically update when superpixels were available
- if you toggled images so that the superpixels were visible you would be unable to paint anything

This required refreshing the page to fix. Bisecting the commits narrowed the problem down to SHA 5ca41b7db667f3f261d53c32c83d3e1609e202b6, however the changes in this commit do not seem to obviously affect the initial labeling step. My best guess is that the additional re-render was somehow messing up the events, and this theory seemed to be supported by the fact that the attempts to paint would be caught for the image event triggers but not the annotation overlay triggers. That said, I was unable to conclusively trace how/when this was happening since this re-render only affected the `ActiveLearningInitialSuperpixels`, before the `ActiveLearningSlideViewer` (which handles all events) is ever mounted for the first time. Regardless, I wanted to note what I found so that if a similar issue arises in the future we have a record of this.

Since both the certainty and feature choices use the same endpoint combining them makes sense and also resolves the issue.